### PR TITLE
Revise standup notes for October 20, 2025

### DIFF
--- a/documents/standups/2025-10-20.md
+++ b/documents/standups/2025-10-20.md
@@ -10,7 +10,7 @@
 
 Today was focused heavily on team training, process improvement, and cross-compilation refinement. Key achievements include:
 <br>
-- TSF Implementation & Training: Initial TSF (Trustable Service Framework) implementation and documentation began. A training session was prepared and finalized for the team, to be presented on Tuesday.
+- TSF Implementation & Training: Initial TSF (Trustable Software Framework) implementation and documentation began. A training session was prepared and finalized for the team, to be presented on Tuesday.
 - Workflow Automation: Implemented Git Actions to improve and automate our development workflows.
 - Documentation & Project Setup: Significant progress was made on the GitHub documentation, particularly refining the Project view and Scrum board setup.
 - Hardware Research: Completed a study on the micro-controller to better inform future hardware and software integration decisions.


### PR DESCRIPTION
Updated the standup notes for October 20, 2025, reflecting the new date and changes in team activities and progress.