### PR TITLE
docs: add daily standup for 2025-10-31

### DIFF
--- a/docs/standups/2025-10-31.md
+++ b/docs/standups/2025-10-31.md
@@ -15,11 +15,11 @@ The team made progress across multiple fronts: hardware integration with GPIO an
 
 ### Bernardo - Hardware Integration & Testing
 - ✅ Switched power-up sequence to test phase version
-- ✅ Soldered cables for GTIO
+- ✅ Soldered cables for GPIO
 - 🔄 Writing script to verify the speed sensor
 
 ### Gaspar - OS & Development Environment
-- ✅ Formatted and successfully booted AGL using the cross sssk image
+- ✅ Formatted and successfully booted AGL using the cross sdk image
 - 🔄 Facing issues with the SDK extended dependencies
 
 ### Hugo - Hardware & Fabrication
@@ -41,7 +41,7 @@ The team made progress across multiple fronts: hardware integration with GPIO an
 
 **Progress on GPIO and CAN bus integration:**
 - Power-up sequence updated to test phase version
-- GTIO cables soldered and ready for testing
+- GPIO cables soldered and ready for testing
 - CAN bus successfully connected to STM32 microcontroller
 
 ---
@@ -49,7 +49,7 @@ The team made progress across multiple fronts: hardware integration with GPIO an
 ## Software
 
 **Progress:**
-- ✅ AGL system formatted and booted successfully with cross sssk image
+- ✅ AGL system formatted and booted successfully with cross sdk image
 - ✅ STM32 development environment showcased
 - ✅ GenAI automation workflow documented and submitted
 - 🔄 SDK extended dependencies troubleshooting
@@ -79,4 +79,4 @@ The team made progress across multiple fronts: hardware integration with GPIO an
 
 ---
 
-**Previous:** [2025-10-30.md](2025-10-30.md) | **Next:** [november03.md](november03.md)
+**Previous:** [2025-10-30.md](2025-10-30.md) | **Next:** [2025-11-03.md](2025-11-03.md)


### PR DESCRIPTION
**Related issue(s):** closes #81

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup log for October 31, 2025 based on team raw notes. The standup covers:
- Hardware integration progress (GPIO, CAN bus, STM32)
- AGL/SDK development environment setup
- TSF artifacts investigation and blockers
- GenAI automation workflow improvements

## How to test / Validation
Review the standup document at `docs/standups/2025-10-31.md` to ensure all team member updates are accurately captured and formatted according to the daily-log-template.

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.