### PR TITLE
docs: Add daily log for November 7, 2025

### DIFF
--- a/docs/standups/2025-11-07.md
+++ b/docs/standups/2025-11-07.md
@@ -8,7 +8,7 @@
 
 ## What We Did Today
 
-Today was focused on preparing and executing the Sprint Retro. Gaspar successfully installed AGL on the SSD and got it running at 100%, while also completing dependency installations on the Micro SD for testing purposes. Melanie worked on incorporating validators into a local extension and attempted packaging as a plugin for Trudag. The team prepared the Sprint Retro presentation, with Bernardo creating the logo and reviewing the presentation, Hugo presenting the retro, and Miguel planning Sprint 3.
+Today was focused on preparing and executing the Sprint Retrospective. Gaspar successfully installed AGL on the SSD and got it running at 100%, while also completing dependency installations on the Micro SD for testing purposes. Melanie worked on incorporating validators into a local extension and attempted packaging as a plugin for Trudag. The team prepared the Sprint Retrospective presentation, with Bernardo creating the logo and reviewing the presentation, Hugo presenting the Retrospective, and Miguel planning Sprint 3.
 
 ---
 
@@ -16,7 +16,7 @@ Today was focused on preparing and executing the Sprint Retro. Gaspar successful
 
 ### Bernardo - Hardware Integration & Testing
 - ✅ Helped preparing the Sprint Retrospective.
-- ✅ Created the logo for the Retro.
+- ✅ Created the logo for the Retrospective.
 - ✅ Reviewed the presentation.
 
 ### Gaspar - OS & Development Environment
@@ -65,7 +65,7 @@ AGL successfully installed and running on SSD at full capacity, with additional 
 
 ## Standards & Research
 
-Sprint Retro completed, providing valuable insights for continuous improvement.
+Sprint Retrospective completed, providing valuable insights for continuous improvement.
 
 ---
 


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #106

## Type of change
- [x] docs: Documentation only changes

## Summary
This PR adds the daily standup log for November 7, 2025 (Day 23 of the SEAME Automotive Journey). 

The daily log documents:
- Sprint Retro preparation and execution
- AGL installation completed on SSD at 100% by Gaspar
- AGL dependencies installed on Micro SD for testing
- Validators integration attempts by Melanie
- Sprint 3 planning by Miguel (starting November 10, 2025)
- Sprint Retro presentation by Hugo with logo design by Bernardo

This documentation is essential for tracking team progress and maintaining our development history.

## How to test / Validation
1. Check that the file `docs/standups/2025-11-07.md` exists
2. Verify the content includes all team members' activities for November 7, 2025
3. Confirm the document follows the established daily log format
4. Verify links to previous/next daily logs are correct

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable (N/A for documentation)
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes) (N/A)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change that adds a new daily log file without modifying existing functionality.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.