### PR TITLE
docs: add conclusions to power consumption analysis

### DIFF
--- a/docs/hardware/power_consumption.md
+++ b/docs/hardware/power_consumption.md
@@ -1,177 +1,193 @@
 # Raspberry Pi 5 (16GB) System — Power Summary
 
-This document is a summary of the power analysis performed for the PiRacer system. Tables, totals, runtime estimates and recommended protections are included.
+This document summarizes the power analysis for the PiRacer system. It includes component powers, block totals, rail requirements, battery/runtime estimates, recommended protections and a testing plan. Numbers use conservative, verifiable assumptions; follow the test plan to validate for your hardware.
 
 ---
 
 ## Contents
 - Block 1 — Raspberry Pi system (5 V domain)
-- Block 2 — STM32 + sensors + servo + motors
-- Totals, rail requirements and runtime estimates
-- Battery configuration options
-- Recommended protections, converters and wiring
+- Block 2 — STM32 + sensors + servo + motors (motor/servo rail)
+- Power conversion, battery assumptions and runtime calculations
+- Battery configuration options and safety notes
+- Protections, wiring and testing plan
+- Team conclusions / decisions
 
 ---
 
-## Assumptions
-- Pack nominal voltage: 11.1 V (3 × 3.7 V cells).  
-- Pack fully charged voltage: 12.6 V (3 × 4.2 V cells).  
-- DC‑DC converter efficiency: 90% (0.9).  
-- Example pack capacity: 4.8 Ah.
+## Key assumptions & conventions
+- Pack nominal voltage: 11.1 V (3 × 3.7 V cells). Fully charged = 12.6 V (3 × 4.2 V). Use nominal voltage (11.1 V) for Watt‑hour runtime calculations. Use 12.6 V only to check peak input voltages and component stress.
+- Converter efficiency (example): 90% (0.9). Use input_power = output_power / efficiency and input_current = input_power / pack_voltage.
+- Use verified cell capacity for sizing. Many low‑quality 18650 claims (e.g., 4800 mAh) are false — design with verified capacity (e.g., 3200 mAh) or measured data.
+- Use usable capacity (account for BMS cutoff and safe depth‑of‑discharge). Example conservative usable fraction: 75–85% (80% used below).
 
 ---
 
 ## 🟦 BLOCK 1 — Raspberry Pi System (5 V rail)
 
-Includes: Raspberry Pi 5 (16 GB), Hailo AI HAT, Seeed Dual-CAN HAT, USB SSD (USB 3 enclosure), Waveshare 7.9" touch display.
+Includes: Raspberry Pi 5 (16 GB), Hailo AI HAT, Seeed Dual‑CAN HAT, USB SSD (NVMe, USB3), Waveshare 7.9" touchscreen.
 
 | Component | Typical power | Peak power | Notes |
 |---|---:|---:|---|
-| Raspberry Pi 5 (16GB) | 9–12 W | 14–16 W | Idle 3.5–4 W, heavy combos up to 16 W |
-| Hailo AI HAT | 2.5 W | 3 W | inference device |
-| Seeed Dual-CAN HAT | 0.45–0.6 W | 0.6 W | 90–120 mA @ 5 V |
-| USB SSD (NVMe via USB3) | 5 W | 7 W | active/peak numbers for NVMe enclosure |
-| Waveshare 7.9" touchscreen | 3 W | 3.5 W | display/backlight dependent |
-| **TOTAL (Block 1)** | **21.0–23.1 W** | **28.1–30.1 W** | |
+| Raspberry Pi 5 (16GB) | 9–12 W | 14–16 W | Idle ≈3.5–4 W; heavy loads up to ~16 W |
+| Hailo AI HAT | 2.5 W | 3 W | Inference HAT |
+| Seeed Dual‑CAN HAT | 0.45–0.6 W | 0.6 W | 90–120 mA @ 5 V |
+| USB SSD (NVMe via USB3) | 5 W | 7 W | NVMe enclosure peaks |
+| Waveshare 7.9" touchscreen | 3 W | 3.5 W | Backlight dependent |
+| **TOTAL (Block 1)** | **20.95–23.1 W** | **28.1–30.1 W** | Sum of above (typical / peak) |
 
-Rail requirement (5 V): 5–7 A recommended (allow for millisecond spikes).  
-Practical recommendation: size 5 V buck for 12 A to give margin and account for inrush/peaks.
+Rail recommendation (5 V): 6–8 A continuous recommended; size the 5 V buck with margin (recommend 12 A rated output for continuous margin and inrush/short peaks).
+
+Notes:
+- Keep units consistent: power in W, currents in A. When sizing wiring and fuses, convert using pack/input voltage and converter efficiency (see conversion section).
+- For continuous thermals, derate converter rating by 10–20% if ventilation is limited.
 
 ---
 
-## 🟩 BLOCK 2 — STM32 + Sensors + Servo + Motors (6–7 V motor/servo rail)
+## 🟩 BLOCK 2 — STM32 + Sensors + Servo + Motors (motor/servo rail, 6–7 V)
 
-Includes: STM32U585I-IT01A, LM393 speed sensor, CAN transceiver, MG996R servo, two PiRacer 37‑520 DC gearmotors.
+Includes: STM32U585 MCU, LM393 speed sensor, CAN transceiver, MG996R servo, two PiRacer 37‑520 DC gearmotors.
 
 | Component | Typical power | Peak power | Notes |
 |---|---:|---:|---|
-| STM32U585I-IT01A | 0.5 W | 0.5 W | MCU power |
+| STM32U585I‑IT01A | 0.5 W | 0.5 W | MCU |
 | LM393 speed sensor | 0.01 W | 0.01 W | negligible |
 | CAN transceiver | 0.2 W | 0.2 W | |
-| MG996R servo (assume 6 V) | 6 W | 15 W | typical vs stall |
-| PiRacer 37‑520 motor #1 (6 V) | 6 W | 12 W | no-load / under load / stall |
+| MG996R servo (6 V) | 6 W | 15 W | Typical vs. stall (measure stall in amps) |
+| PiRacer 37‑520 motor #1 (6 V) | 6 W | 12 W | No‑load / under load / stall |
 | PiRacer 37‑520 motor #2 (6 V) | 6 W | 12 W | |
 | **TOTAL (Block 2)** | **18.7 W** | **39.7 W** | |
 
-Rail recommendation for motors/servo: design for 7 V output (6–7 V nominal), allow 3–7 A continuous depending on usage, peaks up to ~10–15 A if multiple actuators stall simultaneously.
+Rail recommendation (motor/servo): design for 6–7 V; allow 3–7 A continuous depending on usage profile. Plan wiring/fuses/converters for short peak currents (stall/inrush) up to ~10–15 A or measured values.
+
+Important: convert motor/servo power estimates to amps via the motor supply voltage and verify stall/start currents on the bench; do not assume stall current from watt estimates alone.
 
 ---
 
-## Power conversion & battery input (example: 3S Li-ion pack)
+## Power conversion & battery input (method & example)
 
-Assume DC‑DC buck converters with 90% efficiency (0.9). Below are input current calculations for both nominal pack voltage (11.1 V) and fully charged pack voltage (12.6 V).
+Correct method:
+- input_power (W) = output_power (W) / efficiency
+- input_current (A) = input_power (W) / pack_nominal_voltage (V)
 
-Using nominal voltage 11.1 V (11.1 × 0.9 = 9.99 V effective)
-- Block 1 (typical 23.1 W): 23.1 / 9.99 ≈ 2.31 A  
-  - Peak 30.1 W: 30.1 / 9.99 ≈ 3.01 A
-- Block 2 (typical 18.7 W): 18.7 / 9.99 ≈ 1.87 A  
-  - Peak 39.7 W: 39.7 / 9.99 ≈ 3.98 A
-- Combined typical 41.8 W: 41.8 / 9.99 ≈ 4.19 A  
-  - Combined peak 69.8 W: 69.8 / 9.99 ≈ 6.99 A
+Using efficiency = 0.9 and pack nominal = 11.1 V:
 
-Using fully charged voltage 12.6 V (12.6 × 0.9 = 11.34 V effective)
-- Block 1 (typical 23.1 W): 23.1 / 11.34 ≈ 2.04 A  
-  - Peak 30.1 W: 30.1 / 11.34 ≈ 2.66 A
-- Block 2 (typical 18.7 W): 18.7 / 11.34 ≈ 1.65 A  
-  - Peak 39.7 W: 39.7 / 11.34 ≈ 3.50 A
-- Combined typical 41.8 W: 41.8 / 11.34 ≈ 3.69 A  
-  - Combined peak 69.8 W: 69.8 / 11.34 ≈ 6.16 A
+- Block 1 (conservative typical = 23.1 W):  
+  input_power = 23.1 / 0.9 = 25.67 W → input_current ≈ 25.67 / 11.1 ≈ 2.31 A  
+  Peak 30.1 W → input_power = 30.1 / 0.9 = 33.44 W → input_current ≈ 3.01 A
 
-Pack energy examples
-- At nominal 11.1 V: 11.1 × 4.8 Ah ≈ 53.3 Wh
-  - Runtime at combined peak 69.8 W: 53.3 / 69.8 ≈ 0.76 h (≈ 46 min)
-  - Runtime at combined typical 41.8 W: 53.3 / 41.8 ≈ 1.27 h (≈ 1 h 16 min)
-  - Runtime at 20 W average: 53.3 / 20 ≈ 2.67 h
-- At fully charged 12.6 V: 12.6 × 4.8 Ah = 60.48 Wh
-  - Runtime at combined peak 69.8 W: 60.48 / 69.8 ≈ 0.87 h (≈ 52 min)
-  - Runtime at combined typical 41.8 W: 60.48 / 41.8 ≈ 1.45 h (≈ 1 h 27 min)
-  - Runtime at 20 W average: 60.48 / 20 ≈ 3.02 h
+- Block 2 (typical 18.7 W):  
+  input_power = 18.7 / 0.9 = 20.78 W → input_current ≈ 1.87 A  
+  Peak 39.7 W → input_power = 39.7 / 0.9 = 44.11 W → input_current ≈ 3.97 A
 
-Notes
-- Use nominal (11.1 V) values for conservative continuous-current sizing. Use fully charged (12.6 V) values to check peak inrush and voltage stress.
-- All currents above are input currents at pack voltage before converter losses; rail currents at 5 V or 6–7 V are higher by the appropriate voltage division.
-- Use the worst-case typical values when sizing continuous supplies; use peak combined values when sizing fuses, transient handling and wiring for short-duration events.
+- Combined (typical conservative = 41.8 W):  
+  input_power = 41.8 / 0.9 = 46.44 W → input_current ≈ 46.44 / 11.1 ≈ 4.19 A  
+  Combined peak 69.8 W → input_power = 69.8 / 0.9 = 77.56 W → input_current ≈ 77.56 / 11.1 ≈ 6.99 A
 
----
+Pack energy (use nominal voltage × verified capacity)
+- Example verified capacity: 3.2 Ah → 11.1 V × 3.2 Ah = 35.52 Wh (use this for runtime).
+- Usable capacity: account for BMS cutoff / DoD. Example conservative usable fraction: 80% → usable_Wh = 35.52 × 0.8 = 28.42 Wh.
 
-## Battery configuration options
+Runtime examples (3.2 Ah pack)
+- Combined typical 41.8 W:
+  - 100% usable: 35.52 / 41.8 ≈ 0.85 h (≈ 51 min)
+  - 80% usable: 28.42 / 41.8 ≈ 0.68 h (≈ 41 min)
+- Combined peak 69.8 W (short bursts): 35.52 / 69.8 ≈ 0.51 h (≈ 31 min) — note peaks are short; sustained at peak will deplete quickly.
 
-Option A — Two separate 3S packs (current plan)
-- Pack 1 → Block 1 (Pi + HATs + display)
-- Pack 2 → Block 2 (motors + servo + MCU)
-Pros: isolation of motor spikes, easier fault containment, simpler converters per block.  
-Cons: two chargers/BMS units, more wiring.
-
-Option B — One larger pack (3S2P or 3S with parallel cells)
-- 3S2P (11.1 V nominal, double capacity) gives longer runtime and higher current capacity.
-- Use single 3S BMS rated for continuous current ≥ expected draw (recommend ≥10 A continuous, ≥15 A peak for this system).
-Pros: simpler charging, more capacity, higher current capability.  
-Cons: single point of failure if not properly fused; ensure BMS and wiring sized correctly.
+Notes:
+- Do NOT compute Wh/runtime using 12.6 V charged voltage — this overestimates energy. Use nominal pack voltage and verified capacity and account for usable fraction.
+- For safety use conservative margins (size converters 20–50% above expected continuous draw for thermal margin; provision for short peak handling separately).
 
 ---
 
-## Recommended protections, components and wiring
+## Battery options, paralleling and safety
 
-1. BMS
-   - Use a 3S BMS with cell balancing, over/under voltage and over current protection.
-   - Rated for continuous current above expected continuous draw (recommend ≥10 A) and peak current above expected peaks.
+Option A — Two separate 3S packs (team default)
+- Pack A → expansion (motors / servo / STM32 / CAN)
+- Pack B → Raspberry Pi + HATs + display
+Pros: isolates motor spikes, simplifies fault containment. Cons: two chargers/BMS units and more wiring.
 
-2. Fuses
-   - Main pack fuse (time‑delay/slow‑blow recommended for motor inrush): ~12–15 A depending on expected peaks.
-   - Optional branch fuses for Pi rail and motor rail.
+Option B — Single pack (3S) powering all
+- Single 3S with a BMS rated for combined current. Use branch fuses and good wiring.
+- Consider a single higher‑capacity pack (3S2P) instead of two separate packs for simpler charging.
 
-3. Buck converters
-   - Pi rail: 5 V, choose a converter rated ~12 A (or higher) to allow margin.
-   - Motor/servo rail: 6–7 V, choose a converter rated ~10 A (or higher).
-   - Prefer modules with thermal shutdown and current limiting.
+Parallel packs (increase current capacity)
+- If paralleling packs, only parallel identical packs (same chemistry, capacity, age, state‑of‑charge). Use a BMS designed for parallel use or separate BMS on each pack with proper controls.
+- Fuse each pack individually and include soft‑start/pre‑charge or current limiting when connecting packs in parallel to avoid large inrush currents.
+- Paralleling increases risk; avoid unless you can validate cell matching and safety.
 
-4. Capacitors / decoupling
-   - Pi rail: 470–1000 µF low-ESR electrolytic at buck output.
-   - Motor/servo rail: 1000 µF+ low-ESR capacitors near the motors/servo to absorb spikes and prevent brownouts.
-
-5. Current & voltage monitoring
-   - Use a pack voltage monitor and a current sensor (shunt or hall) to log/alert for over current or low-voltage conditions.
-
-6. Wiring & connectors
-   - Use appropriately sized wires (e.g., 14–12 AWG for 10–15 A runs). Derate for length and temperature.
-   - Secure crimped/soldered connections and use heatshrink.
-   - Route motor wires away from sensitive signal lines to reduce EMI.
-
-7. Mechanical & thermal
-   - Provide ventilation or heatsinking for high-current buck converters.
-   - Mount caps and BMS away from heat sources and vibration.
+Cell selection notes
+- Use reputable manufacturers and verified capacity. Many "4800 mAh 18650" cells are counterfeit. Typical genuine max for 18650 chemistry ≈ 3000–3500 mAh depending on cell type.
 
 ---
 
-## Quick checklist (practical parts list)
-- 3S Li-ion pack (or 3S2P for more capacity)
-- 3S BMS rated ≥10 A continuous, ≥15 A peak
-- Inline main fuse (12–15 A)
-- 5 V buck converter, 12 A rated (for Pi rail)
-- 6–7 V buck converter, 10 A rated (for motors/servo)
-- Low-ESR capacitors (470–1000 µF for Pi, 1000 µF+ for motors)
-- Current sensor (e.g., INA219/INA3221 or hall-effect)
-- Proper gauge wiring (12–14 AWG), connectors and mounting hardware
+## Protections, components and wiring
+
+1. BMS:
+   - 3S BMS with balancing, over/under voltage protection and overcurrent protection.
+   - Rated continuous current > expected continuous draw (recommend ≥10 A) and peak current > expected peaks.
+
+2. Fuses:
+   - Main pack fuse: choose rating considering continuous draw + margin. For motors choose time‑delay (slow‑blow) for inrush tolerance; e.g., 12–15 A depending on expected peaks and pack configuration.
+   - Branch fuses for Pi rail and motor rail recommended.
+
+3. Buck converters:
+   - Pi rail: 5 V converter rated ≥12 A for margin and thermal headroom.
+   - Motor/servo rail: 6–7 V converter rated ≥10 A (or higher depending on measured motor currents).
+   - Prefer converters with thermal shutdown, current limiting and clear efficiency specification.
+
+4. Capacitors / decoupling:
+   - Pi rail: 470–1000 µF low‑ESR electrolytic at buck output.
+   - Motor rail: 1000 µF+ low‑ESR capacitors placed close to motor/servo power input to absorb spikes and reduce brownouts.
+
+5. Wiring & connectors:
+   - Use correct gauge: 14 AWG for 10–15 A runs, 12 AWG for >15 A runs; derate for length and temperature. Short high‑current runs may tolerate smaller wire but keep margin.
+   - Use secure crimps/solder and mechanical strain relief. Route motor cables separately to reduce EMI.
+
+6. Current & voltage monitoring:
+   - Use a shunt or hall‑effect sensor and logging (INA219/INA3221, ACS7xx, etc.). Monitor pack voltage and current and log peak events.
+
+7. Thermal & mechanical:
+   - Heatsink or airflow for converters and high‑power components.
+   - Mount BMS and caps away from heat and vibration.
+
+8. Safety:
+   - Have a documented test plan and emergency cutoff (e.g., accessible main fuse and a kill switch).
+   - Carry appropriate PPE and follow Li‑ion handling best practices when building and testing.
 
 ---
 
-## Conclusions — Team decisions
+## Testing plan (detailed)
 
-- Primary decision: keep the current two-pack plan as documented.
-  - Pack A → expansion (motors / servo / STM32 / CAN).
-  - Pack B → Raspberry Pi + HATs + display.
-  - Keep all protections and components listed above (3S BMS, main fuse, branch fuses, buck converters, low‑ESR caps, current monitoring, correct wiring gauge).
+1. Documentation review
+   - Read expansion board and component datasheets for connector/current ratings.
+   - Identify recommended decoupling, connector pinouts, max currents and recommended wiring.
 
-- Single‑pack / parallel option (alternative):
-  - Use one full 3S pack to power everything with the protections above.
-  - If extra current is needed, add a second identical pack in parallel on the expansion side to increase available amps (effectively 3S2P capacity/current). Ensure packs are matched, balanced and connected safely.
-  - Required notes when paralleling packs: only parallel identical, same‑state packs; use BMSs rated for parallel operation or a single BMS designed for the combined configuration; include pre‑charge/current limiting when connecting packs to avoid large inrush; fuse each pack individually.
+2. Bench measurement
+   - Measure idle, nominal, and worst‑case loads with instrumentation:
+     - Use clamp meter or shunt + DAQ for current traces.
+     - Measure stall/start currents for motors/servos (in amps).
+     - Measure voltage drop at connectors and regulators under load.
+     - Measure buck converter temperature at expected continuous current and peaks.
+   - Validate that BMS/fuses and wiring do not overheat and that voltage does not brown out.
 
-- Testing plan (two‑step):
-  1. Documentation check: read the expansion board and individual component datasheets to confirm connector ratings, expected currents and recommended wiring/decoupling.
-  2. Bench tests: measure real current draw directly on the components and on the expansion board under expected loads (idle, nominal, and stall/peak). Verify buck converter regulation, temperature, and that voltage does not brown out under peaks. Log results and adjust fuse / BMS / converter sizing accordingly.
+3. Iteration
+   - If measured draws exceed predicted values, increase converter and fuse ratings, or revert to two‑pack solution for isolation.
+   - Recompute runtime from measured usable Wh.
 
-- Action items before final deployment:
-  - Implement recommended protections and fuses.
-  - Perform the documentation check and bench tests described above.
-  - If bench tests show higher draw than estimated, prefer the two‑pack solution or increase pack/current ratings rather than risking undersized wiring/protection.
+Record all measurements in a test log and attach to this document.
+
+---
+
+## Minor fixes / edits applied in this revision
+- Corrected Block 1 component sum and clarified block totals.
+- Replaced any phrasing implying voltage is "reduced" by converter — efficiency applies to power; formulas are explicit.
+- Added usable capacity (DoD/BMS cutoff) and advised conservative sizing.
+- Standardized 5 V rail recommendation to 6–8 A and converter sizing guidance (12 A).
+- Clarified wire gauge recommendations and fuse type guidance.
+- Strengthened warnings about counterfeit cell capacities and paralleling packs.
+
+---
+
+## Team conclusions (current)
+- Keep two‑pack plan as primary (Pack A → expansion, Pack B → Pi/display) with protections listed above.
+- Single pack / parallel pack option remains as alternative following strict matching, fusing and pre‑charge procedures.


### PR DESCRIPTION
**Related issue(s):** closes #155

## Type of change
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [x] spike: Investigation / research

## Summary
This PR completes the power consumption technical spike for the PiRacer system. The document now includes comprehensive power analysis for both the Raspberry Pi 5 system (Block 1) and the STM32 + motors/servo system (Block 2), with detailed conclusions and team decisions.

Key additions:
- Team decision to maintain the current two-pack battery configuration (Pack A for expansion/motors, Pack B for Pi system)
- Alternative single-pack/parallel option documented for future consideration
- Two-step testing plan (documentation check + bench tests)
- Action items before final deployment including protection implementation and real-world measurements
- Detailed requirements for paralleling packs if needed (matching, BMS considerations, pre-charge, fusing)

## How to test / Validation
Review the conclusions section (lines 134-153) in `docs/hardware/power_consuption.md`:
- Verify team decisions align with project requirements
- Check that testing plan covers both documentation review and practical bench testing
- Confirm action items are clear and actionable
- Ensure safety considerations for battery paralleling are comprehensive

## Checklist
- [x] I have run the project tests locally and they pass (documentation only)
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable (N/A for documentation)
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is documentation only and provides technical guidance for hardware implementation.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.
