### PR TITLE
Eclipse uProtocol spike

### DIFF
--- a/docs/data_transfer/uProtocol_spike.md
+++ b/docs/data_transfer/uProtocol_spike.md
@@ -41,13 +41,13 @@ To transport a \~40-byte uProtocol message over Classic CAN, the system must emp
 The `up-c` (uProtocol C SDK) relies on dynamic features or complex struct mappings.
 
   * **Flash Usage:** The library + Protobuf (NanoPB) runtime requires \~60-100KB.
-  * **RAM Usage:** ISO-TP reassembly buffers require allocating max message size (e.g., 4096 bytes) per connection to avoid overflow, consuming critical SRAM on the STM32G4.
+  * **RAM Usage:** ISO-TP reassembly buffers require allocating max message size (e.g., 4096 bytes) per connection to avoid overflow, consuming critical SRAM on the STM32.
 
 ### 3.2 CPU Overhead
 
-Serialization using NanoPB on Cortex-M4 takes significant cycles compared to raw register copying. While acceptable for telemetry, it introduces jitter in high-frequency ISRs (Interrupt Service Routines) used for motor commutation.
+Serialization using NanoPB on Cortex-M3 takes significant cycles compared to raw register copying. While acceptable for telemetry, it introduces jitter in high-frequency ISRs (Interrupt Service Routines) used for motor commutation.
 
 ## 4\. Recommendation
 
   * **STM32 (Low-Level):** Retain **Pure CAN** (Raw DBC-based signals). It fits the 8-byte frame perfectly without fragmentation.
-  * **RPi5 (High-Level):** Implement uProtocol here. The RPi5 will act as the "Adapter," converting raw CAN frames into uProtocol messages for the rest of the SDV network.
+  * **RPi5 (High-Level):** Implement uProtocol here. The RPi5 will act as the "Adapter," converting raw CAN frames into uProtocol messages for the rest of the Software Defined Vehicle (SDV) network.


### PR DESCRIPTION
**Related issue(s):** closes #193

## Type of change
- [x] spike: Investigation / research

## Summary
This PR adds the research document for Spike #193, which investigates the feasibility of using Eclipse uProtocol to replace custom CAN parsing on the STM32 microcontroller with classic CAN (ISO 11898-1). The investigation concludes that uProtocol is not recommended for the STM32 due to payload constraints (8-byte limit requiring ISO-TP fragmentation), latency issues, memory footprint, and CPU overhead. Instead, retain pure CAN on STM32 and use uProtocol on the RPi5 as a gateway. This aligns with the parent task (#191 SDV Architecture Research) to evaluate transport layers for the DrivaPi platform.

The document includes an executive summary, technical analysis of constraints, resource impacts, and recommendations. No code changes were made, as this is a strict timebox spike (1 day estimate).

Link to design docs: https://github.com/eclipse-uprotocol/up-spec (referenced in notes).

## How to test / Validation
As this is a research spike with no code changes:
1. Review the added document (`uProtocol_spike.md`) for completeness against acceptance criteria:
   - "Yes/No" recommendation: NO for STM32 implementation.
   - List of blockers: Payload overhead, fragmentation latency, memory/CPU constraints.
2. Verify alignment with spike tasks: Reviewed uProtocol specs, checked C SDK availability (up-c), estimated footprints (~60-100KB Flash, large RAM buffers), noted incompatibility with bare STM32 (e.g., no POSIX).
3. No runtime validation needed; discuss findings in ARB review if required.

Expected output: Document confirms uProtocol's unsuitability for STM32, recommending hybrid approach.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a research document with no code, protocol, or database changes. No impact on existing functionality or backward compatibility.

## Related / dependent PRs
- Related to #194 (Kuksa & VSS spike) and #196 (S2S pattern spike) as part of the broader SDV Architecture Research (#191).
- Synthesis PR (if created) will consolidate findings from all spikes.

---

**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.