### PR TITLE
Daily standup for November 28, 2025

### DIFF
--- a/docs/standups/2025-11-28.md
+++ b/docs/standups/2025-11-28.md
@@ -1,0 +1,122 @@
+# Day 38 - SEAME Automotive Journey
+
+**Date:** Thursday, November 28, 2025
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team focused on system infrastructure, deployment automation, and real-time operating system migration. Gaspar resolved AGL dependency issues and successfully migrated the boot process from SSD to microSD card. Bernardo fixed speed sensor ticks calculations and readings. Melanie conducted technical investigations on Kuska, Uprotocol, and VSS, concluding that Kuska is recommended while Uprotocol is not viable for STM32. Hugo completed the GitHub Actions spike with comprehensive documentation on deployment steps. Miguel worked on transitioning motor and servo test code to ThreadX RTOS.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- ✅ Resolved speed sensor issues with ticks calculations/readings
+- ✅ Fixed speed sensor data accuracy
+
+### Gaspar - OS & Development Environment
+- ✅ Installed missing dependencies on AGL (Automotive Grade Linux)
+- ✅ Successfully migrated AGL boot process from SSD to microSD card
+- ✅ Improved system portability and boot configuration
+
+### Hugo - Hardware & Fabrication
+- ✅ Closed GitHub Actions spike investigation
+- ✅ Created Markdown document summarizing findings
+- ✅ Gained clear understanding of deployment steps using GitHub Actions
+
+### Melanie - GUI & Team Coordination
+- ✅ Conducted spikes on Kuska, Uprotocol, and Vehicle Signal Specification (VSS)
+- ✅ Completed Uprotocol analysis: not viable for STM32 microcontroller (no "light" version possible)
+- ✅ Completed Kuska analysis: recommended due to minimal expected losses
+
+### Miguel - GitHub Project & Agile/Scrum
+- 🔄 Working on transition of motor and servo test code to ThreadX RTOS
+- 🔄 Migrating from bare-metal to real-time operating system
+
+---
+
+## Hardware
+
+**Speed Sensor Fix:**
+- Bernardo resolved critical issues with speed sensor ticks calculations
+- Improved accuracy and reliability of speed readings
+- Essential for vehicle speed monitoring functionality
+
+**Boot Configuration Migration:**
+- Gaspar successfully moved AGL boot from SSD to microSD card
+- Enhances system portability and simplifies deployment
+- Required resolving missing dependencies first
+
+---
+
+## Software
+
+**Progress:**
+- ✅ AGL missing dependencies installed (Gaspar)
+- ✅ AGL boot migration to microSD completed (Gaspar)
+- ✅ Speed sensor ticks calculation fixed (Bernardo)
+- ✅ Kuska spike completed - recommended (Melanie)
+- ✅ Uprotocol spike completed - not viable for STM32 (Melanie)
+- ✅ VSS investigation conducted (Melanie)
+- ✅ GitHub Actions spike closed with documentation (Hugo)
+- 🔄 Motor and servo code transition to ThreadX (Miguel)
+
+---
+
+## Challenges
+
+**Problem:** Uprotocol Compatibility with STM32
+- **Who:** Melanie
+- **Impact:** High
+- **Solution:** Determined that Uprotocol cannot be made "light" enough for STM32 compatibility. Decision: Not viable for current hardware architecture.
+
+**Problem:** ThreadX RTOS Migration
+- **Who:** Miguel
+- **Impact:** Medium
+- **Solution:** Actively transitioning motor and servo test code from bare-metal to ThreadX real-time operating system
+
+---
+
+## Decisions
+
+**Communication Protocol Selection:**
+- **Investigation:** Uprotocol vs Kuska for vehicle communication
+- **Uprotocol Conclusion:** Not compatible with STM32 microcontroller; cannot create lightweight version
+- **Kuska Conclusion:** Recommended - minimal expected performance losses
+- **Decision:** Proceed with Kuska implementation for vehicle communication protocol
+
+**Boot Configuration:**
+- **Decision:** Migrate AGL boot from SSD to microSD card
+- **Outcome:** Successfully completed, improving system portability
+- **Impact:** Simplifies deployment and hardware configuration
+
+**Deployment Strategy:**
+- **Investigation:** GitHub Actions capabilities for CI/CD
+- **Outcome:** Hugo documented comprehensive deployment steps
+- **Decision:** Clear path forward for automated deployment using GitHub Actions
+
+---
+
+## Standards & Research
+
+**Vehicle Communication Protocols:**
+- **Kuska:** Recommended for implementation - lightweight with minimal overhead
+- **Uprotocol:** Not viable for STM32 - too heavy for microcontroller constraints
+- **VSS (Vehicle Signal Specification):** Investigation completed for standardized signal definitions
+
+**CI/CD Pipeline:**
+- GitHub Actions spike completed with full documentation
+- Deployment workflow steps clearly defined
+- Ready for implementation phase
+
+**RTOS Migration:**
+- Transitioning to ThreadX for improved real-time performance
+- Motor and servo control being migrated from bare-metal implementation
+
+---
+
+**Previous:** [2025-11-27.md](2025-11-27.md) | **Next:** [2025-12-02.md](2025-12-02.md)


### PR DESCRIPTION
**Related issue(s):** closes #222

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup log for November 28, 2025 documenting team progress on:
- AGL boot migration from SSD to microSD (Gaspar)
- Speed sensor ticks calculation fixes (Bernardo)
- Communication protocol spikes: Kuska recommended, Uprotocol not viable for STM32 (Melanie)
- GitHub Actions deployment documentation completed (Hugo)
- ThreadX RTOS migration for motor/servo code (Miguel)

## How to test / Validation
Review the daily standup document at `docs/standups/2025-11-28.md` to ensure:
- All team member contributions are accurately documented
- Template structure matches previous dailies
- Links to previous/next dailies are correct

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.