### PR TITLE
docs: add Day 39 standup log (Dec 2, 2025)

### DIFF
--- a/docs/standups/2025-12-02.md
+++ b/docs/standups/2025-12-02.md
@@ -16,7 +16,7 @@ The team focused on debugging STM32/Raspberry Pi CAN communication and evaluatin
 
 ### Bernardo - Hardware Integration & Testing
 - 🔄 Debugging STM32 CAN communication issues
-- 🔄 Transitioning from a bare-metal main to a ThreadX implementation
+- 🔄 Transitioning from a bare-metal main application to a ThreadX implementation
 - 🔄 Working to establish reliable CAN communication
 
 ### Gaspar - OS & Development Environment
@@ -34,7 +34,7 @@ The team focused on debugging STM32/Raspberry Pi CAN communication and evaluatin
 ### Melanie - GUI & Team Coordination
 - ✅ Documented UProtocol evaluation conclusions
 - ✅ Determined CAN is unsuitable for implementing UProtocol
-- ✅ Analysis: CAN capacity limited to 8 bits per communication vs. UProtocol's ~40-byte size requirement
+- ✅ Analysis: CAN capacity limited to 8 bytes per communication vs. UProtocol ~40-byte size requirement, just for the header
 - ✅ Conducted Eclipse Kuksa spike research
 
 ### Miguel - GitHub Project & Agile/Scrum
@@ -95,7 +95,7 @@ The team focused on debugging STM32/Raspberry Pi CAN communication and evaluatin
 
 **UProtocol Communication Method**
 - **Decision:** CAN is unsuitable for implementing UProtocol
-- **Rationale:** CAN capacity limitation (8 bytes per communication; standard CAN supports up to 8 bytes [64 bits] per frame) is insufficient for UProtocol's message size (~40 bytes). CAN FD supports up to 64 bytes, but standard CAN is limited to 8 bytes.
+- **Rationale:** CAN capacity limitation (8 bytes per communication; standard CAN supports up to 8 bytes [64 bits] per frame) is insufficient for UProtocol's message size. CAN FD supports up to 64 bytes, but standard CAN is limited to 8 bytes.
 - **Next steps:** Research alternative communication protocols and methods
 
 ---


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #220

## Type of change
- [x] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
This PR adds the daily standup log for December 2, 2025 (Day 39). The team focused on debugging STM32/Raspberry Pi CAN communication and evaluating communication protocols. Key achievements include:
- Identified CAN message conversion errors
- Documented UProtocol limitations and determined CAN is unsuitable for implementing UProtocol
- Conducted Eclipse Kuksa spike research
- Discovered GPIO pin conflicts between motor control and FDCAN

## How to test / Validation
Review the daily log file at `docs/standups/2025-12-02.md` to ensure:
- All team member updates are captured
- Technical details are accurate
- Formatting is consistent with previous daily logs
- Links and navigation to previous/next logs work correctly

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change adding the daily standup log.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.