### PR TITLE
docs: Remote via USB-C Dongle → Bluetooth

### DIFF
--- a/docs/data_transfer/usb_dongle.md
+++ b/docs/data_transfer/usb_dongle.md
@@ -1,20 +1,36 @@
 # Spike: USB PS4 Dongle on B-U585I-IOT02A (STM32U5)
 
 ## Goal
-Verify whether the B-U585I-IOT02A (STM32U585) can act as a USB Host to enumerate a PS4 BT dongle and parse HID reports.
+Evaluate whether the STM32U585 (B-U585I-IOT02A) can act as a USB Host to enumerate a PS4 USB/Bluetooth dongle and process HID reports.
 
-## Findings (theory & expected risks)
-- USB FS Host (UM2839 — B‑U585I‑IOT02A User Manual §7.5.1, §7.5.2)
-- The STM32U5 (U585) supports USB FS Host, and STM32CubeU5 includes USB Host drivers and USBX HID middleware — so software capability exists.
-- From the manual we read: "It is possible to support the Host mode by mounting the 16 MHz HSE clock X1 and setting the SB4 and SB5 solder bridges OFF. In this configuration, be aware that the U27 VL53L5CXV0GC/1 Time-of-Flight sensor does not work anymore." This means that some physical modifications are required to enable Host mode.
-- Community reports (from the ST community) indicate the B‑U585I‑IOT02A may trigger VBUS over‑current protection (TCPP03‑M20) when some USB devices draw current. This can cut VBUS and prevent enumeration. The STM32 manual states: "To protect B‑U585I‑IOT02A from USB overvoltage, a PPS‑compliant USB Type‑C® port protection is used, the TCPP03‑M20 IC‑compliant with IEC6100‑4‑2 level 4."
-- A missing or reduced VBUS capacitance or PD protection behavior can cause host power to be cut even for modest‑power dongles.
+## Findings
+### 1. USB Host Capability
 
-## Pros / Cons (USB vs BLE)
-- USB (Host + HID)
-  - Pros: Standard HID descriptors; direct parsing of HID reports; existing USBX HID middleware.
-  - Cons: VBUS / power‑protection risk on B‑U585I‑IOT02A; potential hardware modifications needed; limited by the physical cable/port.
+- The STM32U585 supports USB FS Host mode.
+- USBX HID Host middleware is available in STM32CubeU5.
+- Host mode requires hardware modifications:
+  - Mount the external 16 MHz HSE
+  - Set solder bridges SB4/SB5 OFF
+  - This disables the VL53L5 ToF sensor
 
-## Conclusion (team decision)
-- Technically feasible but risky on B‑U585I‑IOT02A due to VBUS / over‑current behavior. Treat the USB‑dongle approach as a prototype/spike only.
-- Final decision: we did not choose the USB‑dongle option as the primary integration path. Rationale: the project will receive commands over CAN from the Raspberry Pi AI in the future. Designing firmware now to consume the same command format (instead of heavily investing in a USB‑host dongle path) saves development time and better prepares the system for the planned CAN‑based command flow.
+### 2. VBUS / Power-Protection Limitations
+
+- The TCPP03-M20 USB-C protection IC may shut down VBUS due to false over-current or over-voltage events.
+- ST Community reports show issues even with low-power devices (<150 mA peak).
+- This can prevent USB enumeration and makes Host mode unreliable without further hardware changes.
+
+### 3. HID Parsing
+
+USB enumeration and HID access are technically possible.
+PS4 dongles use vendor-specific HID reports, so custom parsing and polling logic is required.
+Effort is non-trivial.
+
+## Conclusion
+
+USB-dongle integration is feasible but hardware-risky on the B-U585I-IOT02A because of VBUS protection behavior and mandatory board modifications.
+
+## Decision
+
+We will not use the USB-dongle path as the primary integration method.
+
+The final architecture will receive commands over CAN from the Raspberry Pi AI module. Implementing the CAN-based command format now avoids unnecessary firmware refactoring and aligns the system with the long-term design. The USB dongle will remain connected to the Raspberry Pi, as before.


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #202

## Type of change
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [x] spike: Investigation / research

## Summary
This PR adds comprehensive documentation on integrating PS4 controller with STM32U585 via USB-C dongle. The spike document explains the research and feasibility study of using the STM32U585 as a USB host to the dongle and translating commands for the car.

Key additions:
- USB Host integration approach on STM32U585
- USBX HID Host middleware documentation
- Pros/cons of USB dongle directly on stm32 

## How to test / Validation
1. Review the documentation in `/docs/spikes/remote_usb_ble.md`
2. Verify that all spike objectives from issue #202 are addressed
3. Ensure documentation is clear and complete

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable (N/A for documentation)
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is documentation-only change that adds research findings without affecting existing code or functionality.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.