### PR TITLE
docs: add daily standup for 2025-12-05

### DIFF
--- a/docs/standups/2025-12-05.md
+++ b/docs/standups/2025-12-05.md
@@ -1,0 +1,114 @@
+# Day 42 - SEAME Automotive Journey
+
+**Date:** Friday, December 5, 2025
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team completed major milestones including finishing the KUKSA spike, submitting Qt code for review. Sprint Retrospective was presented, pending PRs were reviewed, and STM32-to-Raspberry Pi communication latency testing code was created. ThreadX test code implementation and template refactoring were finalized, with GitHub Actions guidance provided to support CI/CD setup.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- ✅ Finished reviewing all pending Pull Requests (PRs)
+
+### Gaspar - OS & Development Environment
+- ✅ Prepared the Sprint Retrospective presentation and materials
+- ✅ Presented Sprint Retrospective
+
+### Hugo - Hardware & Fabrication
+- ✅ Created code for STM32 to communicate with Raspberry Pi for latency testing
+- ✅ Testing setup complete for communication latency measurements
+- ✅ Assisted Miguel with GitHub Actions implementation guidance
+- ✅ Explained necessary steps for CI/CD workflow setup
+
+### Melanie - GUI & Team Coordination
+- ✅ Finished the KUKSA spike research and implementation
+- ✅ Submitted Qt code for review - awaiting team feedback
+- ✅ Successfully used Kuksa's BitBake as data broker
+- ✅ Deployed KUKSA data broker to Raspberry Pi
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Finalized the implementation of test code via ThreadX
+- ✅ Performed necessary refactoring on templates
+- ✅ Received guidance from Hugo on GitHub Actions setup
+
+---
+
+## Hardware
+
+**Communication Testing:**
+- STM32 to Raspberry Pi communication code created for latency testing
+- Testing infrastructure in place to measure communication performance
+
+---
+
+## Software
+
+**Progress:**
+- ✅ KUKSA spike completed (Melanie)
+- ✅ Qt code submitted for review (Melanie)
+- ✅ Sprint Retrospective presented (Gaspar)
+- ✅ All pending PRs reviewed (Bernardo)
+- ✅ STM32-Raspberry Pi communication latency code created (Hugo)
+- ✅ ThreadX test code implementation finalized (Miguel)
+- ✅ Template refactoring completed (Miguel)
+- ✅ GitHub Actions guidance provided (Hugo)
+
+---
+
+## Achievements
+
+**KUKSA Integration Complete:**
+- **Who:** Melanie
+- **Impact:** High
+- **Details:** Successfully completed KUKSA spike and submitted Qt code for review. 
+
+**Sprint Retrospective Ready:**
+- **Who:** Gaspar, Bernardo
+- **Impact:** Medium
+- **Details:** Sprint Retrospective fully prepared with all PRs reviewed, ready for comprehensive sprint analysis and team improvement discussion.
+
+**Communication Latency Testing:**
+- **Who:** Hugo
+- **Impact:** High
+- **Details:** Created testing infrastructure for STM32-Raspberry Pi communication latency measurements, enabling performance optimization and comparison between different communication protocols.
+
+---
+
+## Decisions
+
+**Qt Code Review:**
+- **Decision:** Qt code submitted for team review
+- **Rationale:** Ensure code quality and team alignment before integration
+- **Next steps:** Team review and feedback, then merge into main branch
+
+**ThreadX Test Implementation:**
+- **Decision:** Finalized ThreadX test code with template refactoring
+- **Rationale:** Improved code maintainability and test coverage
+- **Next steps:** Continue integration testing with hardware
+
+---
+
+## Standards & Research
+
+**KUKSA Data Broker**
+- Ready for integration with vehicle signal specification (VSS)
+- Enables standardized data communication across automotive components
+
+**Communication Latency Analysis**
+- Testing framework created for measuring STM32-Raspberry Pi latency
+- Will provide data for protocol comparison and optimization decisions
+
+**CI/CD Pipeline**
+- GitHub Actions knowledge sharing completed
+- Foundation laid for automated testing and deployment workflows
+
+---
+
+**Previous:** [2025-12-04.md](2025-12-04.md) | **Next:** [2025-12-09.md](2025-12-09.md)


### PR DESCRIPTION
**Related issue(s):** #267 

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup for December 5, 2025 documenting team progress including:
- Qt code submission for review (Melanie)
- Sprint Retrospective preparation (Gaspar)
- All pending PRs reviewed (Bernardo)
- STM32-Raspberry Pi communication latency testing code (Hugo)
- ThreadX test code implementation and template refactoring (Miguel)
- GitHub Actions guidance provided (Hugo to Miguel)

## How to test / Validation
1. Review the daily standup file: `docs/standups/2025-12-05.md`
2. Verify it follows the established format from previous dailies
3. Confirm all team member contributions are accurately documented
4. Check that navigation links to previous/next days are correct

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change that adds a new daily standup file without modifying any existing functionality.

## Related / dependent PRs
None.

 ---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.