### PR TITLE
docs: add daily standup for 2025-12-12

### DIFF
--- a/docs/standups/2025-12-12.md
+++ b/docs/standups/2025-12-12.md
@@ -8,7 +8,7 @@
 
 ## What We Did Today
 
-The team focused on tooling decisions and hardware integration. Testing frameworks were researched, test coverage and static analysis tools were selected, and the new display hardware was set up. The SDK was migrated to Western OS, CAN documentation was written, and Kuksa integration work continued with performance testing.
+The team focused on tooling decisions and hardware integration. Testing frameworks were researched, test coverage and static analysis tools were selected, and the new display hardware was set up. The AGL image was migrated to Weston, CAN documentation was written, and Kuksa integration work continued with performance testing.
 
 ---
 
@@ -20,7 +20,7 @@ The team focused on tooling decisions and hardware integration. Testing framewor
 - 🔄 Display issue identified (needs debugging/follow-up)
 
 ### Gaspar - OS & Development Environment
-- ✅ Changed the Operating System of the cross SDK to Western
+- ✅ Changed the Operating System Image of the cross SDK to Weston
 - 🔄 Display issue identified (needs debugging/follow-up)
 
 ### Hugo - Hardware & Fabrication
@@ -51,7 +51,7 @@ The team focused on tooling decisions and hardware integration. Testing framewor
 ## Software
 
 **Progress:**
-- ✅ Cross SDK OS migrated to Western
+- ✅ Cross SDK Image migrated to Weston
 - ✅ Kuksa feeder configurations completed
 - ✅ Python to C++ code conversion for Kuksa integration
 - ✅ Latency testing completed
@@ -86,8 +86,8 @@ The team focused on tooling decisions and hardware integration. Testing framewor
 - Completed evaluation of test coverage, Unity testing framework, and static analysis options
 - **Decision:** Tools selected and documented by Miguel for team review
 
-**SDK Operating System:**
-- **Decision:** Migrated cross SDK to Western OS (completed by Gaspar)
+**AGL Operating System:**
+- **Decision:** Migrated cross SDK to Weston (completed by Gaspar)
 
 ---
 


### PR DESCRIPTION
**Related issue(s):** closes #282

## Type of change
- [x] docs: Documentation only changes

## Summary
Added the daily standup document for December 12, 2025, documenting team activities and individual contributions:
- Testing frameworks research and display hardware setup (Bernardo)
- Cross SDK OS migration to Western (Gaspar)
- CAN documentation and hardware functionality study (Hugo)
- Kuksa feeder configuration and Python to C++ conversion (Melanie)
- Test coverage and static analysis tools spike (Miguel)

## How to test / Validation
Review the standup document at `docs/standups/2025-12-12.md` for accuracy and completeness.

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.