### PR TITLE
docs: add daily standup for December 16, 2025

### DIFF
--- a/docs/standups/2025-12-16.md
+++ b/docs/standups/2025-12-16.md
@@ -1,0 +1,81 @@
+# Day 48 - SEAME Automotive Journey
+
+**Date:** Tuesday, December 16, 2025
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+Testing infrastructure development advanced with unit test implementation using Unity and CMock, coverage reporting setup, and static analysis workflow using CodeQL. CAN bidirectional communication was proved, OS updates included preempt-RT patches, and latency testing implementation began on Linux.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- 🔄 Started unit tests for velocity functionality
+- 🔄 Divided unit tests into classifications
+
+### Gaspar - OS & Development Environment
+- ✅ Updated OS to include preempt-RT patches
+- 🔄 Fixing AGL on host machine
+- ✅ Configured Dependabot to verify and update dependencies on weekly basis
+
+### Hugo - Hardware & Fabrication
+- ✅ Proved CAN bidirectional communication
+- ✅ Started static analysis workflow using CodeQL analysis
+
+### Melanie - GUI & Team Coordination
+- 🔄 Implementing Kuksa latency tests on Linux
+- ✅ Created pull request for Kuksa reader class implementation
+- ✅ Discovered Kuksa limiter preventing reception of all CAN messages
+- ✅ Compiled Qt successfully (early afternoon after fix dependency issues)
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Started implementing tools for static testing
+- ✅ Implemented Unity with CMock framework
+- ✅ Created initial unit tests
+- ✅ Configured coverage report generation in HTML
+- 🔄 Working on SonarQube integration for coverage reporting
+
+---
+
+## Software
+
+**Progress:**
+- ✅ Unity and CMock testing framework implemented
+- ✅ CodeQL static analysis workflow configured
+- ✅ Coverage reporting setup (HTML format)
+- ✅ CAN bidirectional communication validated
+- ✅ Kuksa reader class implementation completed
+- 🔄 SonarQube integration for coverage reports
+- 🔄 Latency testing implementation on Linux
+- 🔄 Unit tests for velocity functionality
+
+---
+
+## Challenges
+
+**Problem:** Dependency Installation Issues
+- **Who:** Melanie
+- **Impact:** Medium
+- **Solution:** Resolved dependencies, successfully compiled Qt by early afternoon
+
+---
+
+## Standards & Research
+
+**Testing Infrastructure:**
+- Unity framework with CMock for embedded unit testing
+- HTML coverage reports generated
+- SonarQube evaluation for enhanced coverage reporting
+
+**Static Analysis:**
+- CodeQL workflow implemented for automated code analysis
+- Dependabot configured for weekly dependency updates
+
+---
+
+**Previous:** [2025-12-15.md](2025-12-15.md) | **Next:** [2025-12-17.md](2025-12-17.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #284

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup documentation for December 16, 2025 (Day 48). This standup covers the team's progress on testing infrastructure development including Unity/CMock implementation, CodeQL static analysis workflow, coverage reporting setup, CAN bidirectional communication validation, OS updates with preempt-RT patches, and latency testing implementation on Linux.

## How to test / Validation
1. Review the standup file at `docs/standups/2025-12-16.md`
2. Verify all team members' updates are documented
3. Confirm the file follows the established standup template format
4. Check that navigation links to previous/next standups are correct

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change that adds a new standup file without modifying existing functionality.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.
