### PR TITLE
docs: Add daily standup for December 19, 2025

### DIFF
--- a/docs/standups/2025-12-19.md
+++ b/docs/standups/2025-12-19.md
@@ -18,7 +18,7 @@ Today marked the completion of Sprint 5 with successful finalization of CI/CD pi
 - ✅ Successfully finalized all testing procedures for the speedometer module
 
 ### Gaspar - OS & Development Environment
-- ✅ Completed the migration from the Minimal OS cross-SDK to the Western environment
+- ✅ Completed the migration from the Minimal OS cross-SDK to the Weston environment
 
 ### Hugo - Hardware & Fabrication
 - ✅ Assisted Miguel with CI setup
@@ -47,7 +47,7 @@ Today marked the completion of Sprint 5 with successful finalization of CI/CD pi
 - ✅ Coverage reports automated in CI/CD
 - ✅ Static analysis optimized (external libraries excluded)
 - ✅ Speedometer module testing completed
-- ✅ OS migration from Minimal OS cross-SDK to Western environment completed
+- ✅ OS migration from Minimal OS cross-SDK to Weston environment completed
 
 ---
 
@@ -66,7 +66,7 @@ Today marked the completion of Sprint 5 with successful finalization of CI/CD pi
 - **Decision:** Automated triggers configured for every push to main and Pull Request with mandatory unit tests, coverage reports, and static analysis checks
 
 **Development Environment:**
-- **Decision:** Completed migration to Western environment for improved development workflow
+- **Decision:** Completed migration to Weston environment for improved development workflow
 
 ---
 


### PR DESCRIPTION
**Related issue(s):** #327

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup notes for December 19, 2025, documenting the team's progress on Sprint 5 completion, including:
- Sprint Retrospective facilitation
- CI pipeline implementation with automated triggers
- Unit testing finalization with full coverage
- Static analysis optimization
- Speedometer module testing completion
- OS migration from Minimal OS cross-SDK to Western environment

## How to test / Validation
Review the daily standup file at `docs/standups/2025-12-19.md` to ensure:
- All team member contributions are properly documented
- Format follows the established template
- Links to previous/next days are correct

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.