### PR TITLE
docs: add daily standup for 2026-01-09

### DIFF
--- a/docs/standups/2026-01-09.md
+++ b/docs/standups/2026-01-09.md
@@ -1,0 +1,97 @@
+# Day 56 - SEAME Automotive Journey
+
+**Date:** Friday, January 9, 2026
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team made significant progress on code refactoring, testing automation, and documentation. Key achievements included completing the STM32 firmware refactor, finishing unit test automation with TSF, integrating Doxygen documentation into CI/CD, refactoring Qt application and archives, and advancing sensor research for CAN-FD vs. CAN-BUS comparison.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- ✅ Finished the STM32 code refactor
+- 🔄 Pending: IDE testing to verify everything is correct
+
+### Gaspar - OS & Development Environment
+- ✅ Refactored the Qt application and Archives
+- ✅ Created the Code of Conduct
+- ✅ Removed unnecessary assets
+
+### Hugo - Hardware & Fabrication
+- ✅ Finished Doxygen documentation
+- ✅ Integrated Doxygen into Actions
+- ✅ Created the ThreadX workflow diagram
+
+### Melanie - GUI & Team Coordination
+- ✅ Finished unit test automation with TSF
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Completed the STM32 sensor study
+- 🔄 Currently finalizing the presentation on sensor options
+- 🔄 Started studying distance sensors to compare CAN-FD vs. CAN-BUS
+
+---
+
+## Hardware
+
+**No hardware updates today**
+
+---
+
+## Software
+
+**Progress:**
+- ✅ STM32 firmware refactor completed (Bernardo)
+- ✅ Unit test automation with TSF completed (Melanie)
+- ✅ Doxygen documentation finalized and integrated into CI/CD (Hugo)
+- ✅ ThreadX workflow diagram created (Hugo)
+- ✅ Qt application and Archives refactored (Gaspar)
+- ✅ Code of Conduct created (Gaspar)
+- ✅ STM32 sensor study completed (Miguel)
+- 🔄 IDE testing for STM32 code verification pending (Bernardo)
+- 🔄 Sensor options presentation in progress (Miguel)
+- 🔄 Distance sensor research for CAN-FD vs. CAN-BUS comparison ongoing (Miguel)
+
+---
+
+## Challenges
+
+**Problem:** STM32 Code Verification
+- **Who:** Bernardo
+- **Impact:** Medium
+- **Solution:** Pending IDE testing to verify the refactored STM32 code is working correctly
+
+---
+
+## Decisions
+
+**Code of Conduct:**
+- **Decision:** Created and established Code of Conduct for the project to ensure professional collaboration
+
+**Repository Cleanup:**
+- **Decision:** Removed unnecessary assets to streamline repository
+
+**CI/CD Enhancement:**
+- **Decision:** Integrated Doxygen documentation generation into GitHub Actions for automated documentation updates
+
+---
+
+## Standards & Research
+
+- STM32 firmware refactoring and standards compliance
+- Trustable Software Framework (TSF) unit test automation
+- Doxygen automated documentation generation
+- ThreadX workflow architecture documentation
+- Code of Conduct establishment
+- STM32 sensor evaluation and selection
+- CAN-FD vs. CAN-BUS comparative analysis for distance sensors
+
+---
+
+**Previous:** [2026-01-08.md](2026-01-08.md) | **Next:** [2026-01-12.md](2026-01-12.md)


### PR DESCRIPTION
**Related issue(s):** closes #356

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup for January 9, 2026 (Day 56) documenting team progress including:
- Bernardo: Finished STM32 code refactor, pending IDE testing
- Gaspar: Refactored Qt application and Archives, created Code of Conduct, removed unnecessary assets
- Hugo: Finished Doxygen documentation, integrated into Actions, created ThreadX workflow diagram
- Melanie: Finished unit test automation with TSF
- Miguel: Completed STM32 sensor study, finalizing presentation, started CAN-FD vs CAN-BUS comparison study

## How to test / Validation
- Review the standup file at `docs/standups/2026-01-09.md`
- Verify formatting follows the template
- Confirm all team member updates are accurately captured

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approval. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.