### PR TITLE
docs: add daily log for January 23, 2026 (Day 65)

### DIFF
--- a/docs/standups/2026-01-23.md
+++ b/docs/standups/2026-01-23.md
@@ -1,0 +1,96 @@
+# Day 65 - SEAME Automotive Journey
+
+**Date:** Friday, January 23, 2026
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+Today the team focused on testing and integration: Gaspar conducted multiple bitbake builds testing PREEMPT real-time configurations, Melanie enhanced unit test reporting with individual motor, servo, and speed unit reports. Bernardo continued ultrasonic sensor implementation while Hugo worked on functional tests and Miguel progressed on STM32 sensor development.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- 🔄 Implementing ultrasonic sensor functionality
+- 🔄 Refining sensor data processing and integration
+
+### Gaspar - OS & Development Environment
+- ✅ Performed multiple bitbake builds to test PREEMPT (Real-Time)
+- ✅ Validated real-time kernel configuration
+- 🔄 Optimizing build configuration for real-time performance
+
+### Hugo - Hardware & Fabrication
+- 🔄 Working on functional tests
+- 🔄 Validating hardware integration with functional test suite
+
+### Melanie - GUI & Team Coordination
+- ✅ Reviewed unit test scripts
+- ✅ Added individual reporting for motor, servo, and speed units
+- 🔄 Enhancing test coverage and documentation
+
+### Miguel - GitHub Project & Agile/Scrum
+- 🔄 Working on STM32 sensors
+- 🔄 Developing sensor integration code for STM32
+
+---
+
+## Hardware
+
+**Ultrasonic Sensor:**
+- Bernardo continued implementation work on the ultrasonic sensor, building on the previous day's mounting and code development work.
+
+---
+
+## Software
+
+**Progress:**
+- ✅ Multiple bitbake builds completed with PREEMPT real-time testing (Gaspar)
+- ✅ Unit test scripts enhanced with individual motor/servo/speed reporting (Melanie)
+- 🔄 Functional test development (Hugo)
+- 🔄 STM32 sensor code development (Miguel)
+- 🔄 Ultrasonic sensor implementation (Bernardo)
+
+**Key Commits:**
+- Naming convention documentation updates for C and Qt standards
+- Coverage reporting enhancements with XML generation
+- KUKSA feeder CLI options improvements
+- Error handling enhancements in KUKSA and CAN readers
+
+---
+
+## Challenges
+
+**Problem:** Real-Time Kernel Configuration
+- **Who:** Gaspar
+- **Impact:** Medium
+- **Solution:** Running multiple bitbake iterations to test and validate PREEMPT real-time configuration for optimal performance
+
+**Problem:** Test Reporting Granularity
+- **Who:** Melanie
+- **Impact:** Low
+- **Solution:** Added individual reporting units for motor, servo, and speed to improve test result visibility and debugging
+
+---
+
+## Decisions
+
+**Real-Time Testing Approach:**
+- **Decision:** Conduct multiple bitbake iterations to thoroughly validate PREEMPT real-time kernel configuration before deployment
+
+**Test Reporting Structure:**
+- **Decision:** Split unit test reporting into individual components (motor, servo, speed) for better granularity and debugging capability
+
+---
+
+## Standards & Research
+
+**Real-Time Linux (PREEMPT):**
+- Team is implementing and testing PREEMPT real-time kernel patches to ensure deterministic timing for automotive control systems, critical for safety and performance requirements.
+
+---
+
+**Previous:** [2026-01-22.md](2026-01-22.md) | **Next:** [2026-01-26.md](2026-01-26.md)


### PR DESCRIPTION
**Related issue(s):** closes #420

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup log for January 23, 2026 (Day 65). The log documents:
- Gaspar's bitbake builds testing PREEMPT real-time configurations
- Melanie's enhancements to unit test reporting with individual motor, servo, and speed units
- Bernardo's continued ultrasonic sensor implementation
- Hugo's functional test development
- Miguel's STM32 sensor work

## How to test / Validation
Review the markdown file at `docs/standups/2026-01-23.md` to ensure:
- Correct formatting and navigation links
- All team member updates are captured
- Day counter incremented correctly (Day 65)
- Git activity from Jan 23 reflected in the log

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None

## Related / dependent PRs
None

---
**Approval:** Requires a minimum of **1** approval. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.