### PR TITLE
docs: add daily log for January 27, 2026 (Day 67)

### DIFF
--- a/docs/standups/2026-01-27.md
+++ b/docs/standups/2026-01-27.md
@@ -1,0 +1,105 @@
+# Day 67 - SEAME Automotive Journey
+
+**Date:** Tuesday, January 27, 2026
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+Focused on hardware improvements and testing framework development. Bernardo improved ultrasonic sensor accuracy, Hugo completed the battery pack setup, Melanie advanced testing requirements, Gaspar made progress on AGL RT implementation, and Miguel successfully integrated temperature and humidity sensors on the STM32.
+
+---
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- ✅ Improved ultrasonic sensor accuracy from 60cm to 130cm detection range
+- ✅ Optimized sensor reading timing to 250 microseconds per reading
+- 🔄 Fine-tuning sensor calibration for better accuracy
+
+### Gaspar - OS & Development Environment
+- ✅ Discovered RT limitations on AGL with Raspberry Pi 5 (only compatible with Pi 4)
+- ✅ Implemented threading in AGL for faster data reading
+- 🔄 Working on CPU isolation to accelerate data processing
+
+### Hugo - Hardware & Fabrication
+- ✅ Finalized battery pack configuration (2S2P)
+- ✅ Connected battery pack to step-down converter
+- ✅ Designed and implemented switch between step-down and battery pack
+- ✅ Created integration tests definition file
+- ✅ Successfully completed PS3 remote integration test with Raspberry Pi
+
+### Melanie - GUI & Team Coordination
+- ✅ Created new user requirements documentation
+- ✅ Defined functional tests to validate new requirements
+- ✅ Incorporated existing unit and static tests for speed sensor and DC motor
+- 🔄 Awaiting facilitator confirmation on requirements validation
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Successfully displayed temperature from STM32 embedded sensor
+- ✅ Implemented humidity sensor display with calibration
+- ✅ Configured both sensors to read via I2C2 interface
+
+---
+
+## Hardware
+
+**Battery Pack Integration:**
+- Completed 2S2P battery pack configuration
+- Integrated step-down converter with control switch
+- Successful PS3 remote controller integration with Raspberry Pi
+
+**Ultrasonic Sensor Optimization:**
+- Improved detection range from 60cm to 130cm
+- Optimized reading timing to 250 microseconds
+
+---
+
+## Software
+
+**Progress:**
+- ✅ STM32 temperature sensor reading and display via I2C2
+- ✅ STM32 humidity sensor reading with calibration via I2C2
+- ✅ AGL threading implementation for improved performance
+- ✅ Integrated unit tests for speed sensor and DC motor
+- 🔄 CPU isolation implementation for AGL data processing
+- 🔄 User requirements documentation and validation
+
+---
+
+## Challenges
+
+**Problem:** AGL Real-Time Compatibility
+- **Who:** Gaspar
+- **Impact:** Medium
+- **Solution:** Discovered RT is only compatible with Raspberry Pi 4, not Pi 5. Implementing threading and CPU isolation as alternative optimization strategies.
+
+**Problem:** Ultrasonic Sensor Range Limitation
+- **Who:** Bernardo
+- **Impact:** Medium
+- **Solution:** Adjusted reading timing to 250 microseconds, increasing detection range from 60cm to 130cm.
+
+**Problem:** Humidity Sensor Calibration
+- **Who:** Miguel
+- **Impact:** Low
+- **Solution:** Successfully calibrated sensor for accurate readings via I2C2.
+
+---
+
+## Decisions
+
+**Battery Pack Switch:**
+- Option A: Direct connection between step-down and battery pack
+- Option B: Add switch for manual control
+- **Decision:** Implemented switch for better control and safety
+
+**AGL Performance Optimization:**
+- Option A: Wait for RT support on Pi 5
+- Option B: Use threading and CPU isolation
+- **Decision:** Proceed with threading and CPU isolation for immediate performance gains
+
+---
+
+**Previous:** [2026-01-26.md](2026-01-26.md) | **Next:** [2026-01-28.md](2026-01-28.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #417

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily log entry for January 27, 2026 (Day 67) documenting the day's progress, team activities, challenges, and decisions. 

## How to test / Validation
1. Review the daily log file at `docs/standups/2026-01-27.md`
2. Verify the log follows the established format and template
3. Check that navigation links to previous/next logs work correctly
4. Confirm all team members' activities are documented

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change that adds a daily log entry.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approval. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.