### PR TITLE
docs: add daily log for January 28, 2026 (Day 68)

### DIFF
--- a/docs/standups/2026-01-28.md
+++ b/docs/standups/2026-01-28.md
@@ -1,0 +1,112 @@
+# Day 68 - SEAME Automotive Journey
+
+**Date:** Wednesday, January 28, 2026
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+***
+
+## What We Did Today
+
+Advanced integration between STM32, Raspberry Pi, and the remote control, focusing on CAN communication and joystick control. The team investigated and fixed a hardware issue blocking remote control functionality, progressed on emergency braking logic, and continued improving test automation and sensor integration.
+
+***
+
+## Team Progress
+
+### Bernardo - Hardware Integration & Testing
+- ✅ Performed multiple tests on ultrasonic sensor; current reliable range remains at 130 cm
+- ✅ Started designing emergency braking and failsafe logic (no acceleration allowed if object < 10 cm)
+- 🔄 Studying how to derive velocity and safe braking time from distance measurements between two points
+
+### Gaspar - OS & Development Environment
+- ✅ Improved CAN communication logic in Rust for remote control
+- ✅ Refactored code so CAN messages are now sent periodically with a delay instead of only on updates
+- 🔄 Supporting further integration and optimization of remote control behavior
+
+### Hugo - Hardware & Fabrication
+- ✅ Implemented code to automate integration tests
+- 🔄 Defining and implementing a deployment strategy for integration test code on both STM32 microcontroller and Raspberry Pi
+
+### Melanie - GUI & Team Coordination
+- ✅ Collaborated with Gaspar and Miguel to debug non-working remote control logic (Rust + STM32)
+- ✅ Helped identify and resolve an underlying hardware issue affecting remote control
+- 🔄 Simplifying and refining requirements documentation
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Integrated temperature and humidity sensors with defined CAN IDs
+- ✅ Implemented periodic CAN transmission every 10 seconds for temperature and humidity data
+- ✅ Worked with Gaspar on Rust joystick logic to control servo and DC motor
+- 🔄 Pending integration of battery data, accelerometer, and gyroscope into CAN messages
+
+***
+
+## Hardware
+
+**Remote Control & Servo Behavior:**
+- Identified mismatch between “90 degrees” in ThreadX logic and the actual physical neutral position of the servo
+- Observed that on shutdown the servo moves to the left, indicating 0-point misalignment
+- Investigated and corrected a hardware-related issue that was preventing the remote control logic from working correctly
+
+***
+
+## Software
+
+**Progress:**
+- ✅ CAN IDs defined for temperature and humidity sensors
+- ✅ Temperature and humidity values sent via CAN every 10 seconds
+- ✅ Refactored Rust CAN logic to send periodic messages (not only on state changes)
+- ✅ Implemented joystick logic path from Rust to servo and DC motor control
+- ✅ Automation code for integration tests created
+- 🔄 Deployment strategy for integration tests to STM32 and Raspberry Pi
+- 🔄 Integration of battery, accelerometer, and gyroscope data into CAN frames
+- 🔄 Refinement and simplification of requirements
+
+***
+
+## Challenges
+
+**Problem:** Servo Neutral Position Mismatch
+- **Who:** Miguel & Gaspar
+- **Impact:** Medium
+- **Solution:** Identified that the 90-degree value in ThreadX did not correspond to the physical neutral angle; analyzed servo behavior (including movement to the left on shutdown) and adjusted logic and expectations around the servo’s zero point.
+
+**Problem:** Remote Control Logic Not Working
+- **Who:** Melanie, Gaspar & Miguel
+- **Impact:** High
+- **Solution:** Jointly reviewed Rust and STM32 code paths and eventually traced the issue to a hardware problem. After fixing the hardware, remote control communication and logic became functional.
+
+**Problem:** CAN Messages Only Sent on Updates
+- **Who:** Gaspar
+- **Impact:** Medium
+- **Solution:** Refactored Rust CAN implementation so that messages are sent periodically using a delay mechanism, ensuring consistent updates even when values do not change.
+
+**Problem:** Limited Ultrasonic Sensor Range
+- **Who:** Bernardo
+- **Impact:** Medium
+- **Solution:** Continued systematic testing; current stable range remains at 130 cm while parallel work started on emergency braking logic and failsafe behavior based on distance thresholds.
+
+***
+
+## Decisions
+
+**CAN Message Strategy for Remote Control:**
+- Option A: Send CAN frames only when state changes occur
+- Option B: Send CAN frames periodically with a defined delay
+- **Decision:** Use periodic CAN messages with delay to ensure consistent, predictable communication and easier debugging.
+
+**Emergency Braking Failsafe:**
+- Option A: Allow acceleration regardless of distance and only warn the user
+- Option B: Block acceleration when an object is detected closer than 10 cm
+- **Decision:** Implement failsafe logic where acceleration is not allowed if an object is detected below 10 cm, and use distance over time to compute velocity and safe braking time.
+
+***
+
+## Standards & Research
+
+- Ongoing refinement of requirements to keep them aligned with actual system behavior and easier validation
+- Exploration of approaches to calculate velocity and braking distance from discrete distance measurements (time-based derivation for safe emergency braking logic)
+
+***
+
+**Previous:** [2026-01-27.md](2026-01-27.md) | **Next:** [2026-01-29.md](2026-01-29.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #424 

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily log entry for January 28, 2026 (Day 68) documenting the day's progress, team activities, challenges, and decisions. 

## How to test / Validation
1. Review the daily log file at `docs/standups/2026-01-28.md`
2. Verify the log follows the established format and template
3. Check that navigation links to previous/next logs work correctly
4. Confirm all team members' activities are documented

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None. This is a documentation-only change that adds a daily log entry.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approval. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.