### PR TITLE
docs: Add daily standup for 2026-02-03

### DIFF
--- a/docs/standups/2026-02-03.md
+++ b/docs/standups/2026-02-03.md
@@ -95,7 +95,7 @@ Team made significant progress on testing infrastructure and automation. Hugo co
 ## Decisions
 
 - **Unit Test Architecture**: Moving from static copied files to dynamic file sourcing that adapts to code updates automatically
-- **Coverage Enforcement**: PRs now fail if coverage decreases, ensuring code quality standards
+- **Coverage Enforcement**: PRs now fail if coverage decreases or increases and if baseline is not updated, ensuring this is an intencional behaviour
 - **Module-Specific Reporting**: Each component (dc_motor, servo_motor, speed_sensor) generates separate coverage reports for better visibility
 
 ---


### PR DESCRIPTION
**Related issue(s):** closes #435

## Type of change
- [x] docs: Documentation only changes

## Summary
Added daily standup log for February 3, 2026 (Day 72). Documented team progress including:
- Hugo's completion of DC and servo motor integration tests with evidence
- Melanie's implementation of module-specific coverage reports and differential coverage validation
- Gaspar's resolution of STM32 firmware merge conflicts and improved automation
- Bernardo's unit test architecture evaluation
- Miguel's work on dynamic test file sourcing system

## How to test / Validation
1. Review the daily log at `docs/standups/2026-02-03.md`
2. Verify all sections are properly filled
3. Check navigation links work correctly
4. Confirm day counter is sequential (Day 72)

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [x] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None - documentation only change.

## Related / dependent PRs
None

---
**Approval:** Requires a minimum of **1** approval. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.