### PR TITLE
Fix for Empty except

### DIFF
--- a/dotstop/dotstop_extensions/validators.py
+++ b/dotstop/dotstop_extensions/validators.py
@@ -196,6 +196,9 @@ try:
         try:
             _fn.__signature__ = Validator._SIGNATURE
         except Exception:
+            # Best-effort: failure to set a custom __signature__ should not
+            # prevent the validators from working, so we intentionally ignore
+            # any errors here (e.g., missing attribute support).
             pass
 except Exception:
     pass


### PR DESCRIPTION
To fix the problem, we should make the `except` clause do something meaningful or clearly document that exceptions are intentionally ignored. The safest approach that does not change existing functionality is to add a brief comment explaining why failures are ignored and optionally narrow the exception type to the expected ones. However, narrowing the type could change behavior if other exception types are currently being silently swallowed. To fully preserve behavior, we will keep catching `Exception` but add an explanatory comment to satisfy the rule, while still using `pass` so the runtime semantics are unchanged.

Concretely, in `dotstop/dotstop_extensions/validators.py`, inside the loop `for _fn in _validator_fns:`, we will modify the inner `except Exception:` block (lines 196–199). We will keep the structure and add a multi-line comment describing that signature patching is best-effort and failures are intentionally ignored. We will not touch the outer `except Exception:` at lines 200–201 since CodeQL only reported the inner one and the outer one wraps an optional import where failure is clearly benign. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._