### PR TITLE
Fix for Empty except

### DIFF
--- a/dotstop/dotstop_extensions/validators.py
+++ b/dotstop/dotstop_extensions/validators.py
@@ -197,5 +197,6 @@ try:
             _fn.__signature__ = Validator._SIGNATURE
         except Exception:
             pass
-except Exception:
+except ImportError:
+    # Optional dependency: if trudag is not installed, validators still work without signature patching.
     pass


### PR DESCRIPTION
To fix the problem, we should ensure that the `except` clause either (a) has an explanatory comment indicating why ignoring the exception is safe and intentional, or (b) performs some meaningful action, such as logging or restricting the caught exception type. The best fix that preserves existing functionality while improving robustness is to narrow the outer `except` to catch only `ImportError` (the expected, harmless case when `trudag` is not installed). Unexpected exceptions (e.g., programming errors) will then surface normally. If we also want to satisfy the rule strictly about “does nothing but pass,” we can add a brief comment explaining that the validator integration is optional.

Concretely, in `dotstop/dotstop_extensions/validators.py` near lines 186–201:
- Change the outer `except Exception:` to `except ImportError:` and add a short comment in the body clarifying that missing `trudag` is acceptable and the module still functions without it.
- Keep the inner `except Exception: pass` (around `__signature__` assignment) unchanged, because it does perform a specific, localized, intentionally-best-effort operation; CodeQL did not flag that in the report, and changing it could risk compatibility behavior.

No new imports or helper methods are required; we only edit this try/except block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._