### PR TITLE
docs: Add daily log for 2026-02-11

### DIFF
--- a/docs/standups/2026-02-11.md
+++ b/docs/standups/2026-02-11.md
@@ -1,0 +1,86 @@
+# Day 78 - SEAME Automotive Journey
+
+**Date:** Wednesday, February 11, 2026
+
+**Team:** Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team worked on hardware soldering, battery voltage monitoring code, and continued troubleshooting the Qt deployment pipeline. We also participated in a team-building escape room event to strengthen collaboration.
+
+---
+
+## Team Progress
+
+### Bernardo (Testing)
+
+* ✅ Delivered external presentation
+* ✅ Performed hardware soldering tasks
+
+### Gaspar (OS & Development Environment)
+
+* ✅ Worked on the retrospective presentation
+* 🔄 Assisted Melanie with Qt deployment debugging
+
+### Hugo (Hardware & Fabrication)
+
+* ✅ Created code to integrate the sensor for reading voltage from the Raspberry Pi 5 battery pack
+
+### Melanie (GUI & Team Coordination)
+
+* 🔄 Investigating Qt deployment issue (identified that only QML files are failing to update)
+* 🔄 Verified that bitbaking without cache works as a temporary workaround
+
+### Miguel (GitHub Project & Agile/Scrum)
+
+* ✅ Worked on Unit Tests
+
+---
+
+## Hardware
+
+### Battery Monitoring
+
+* **Voltage Sensor Integration:** Hugo implemented the code to interface with the voltage sensor, allowing the system to monitor the battery pack powering the Raspberry Pi 5.
+
+### Assembly
+
+* **Soldering:** Bernardo worked on soldering necessary hardware components for the current module.
+
+---
+
+## Software
+
+### Qt Application Deployment
+
+* 🔄 **QML Update Issue:** Melanie and Gaspar discovered that changes to QML files are not being picked up during standard deployment. A temporary workaround involves rebuilding the recipe without cache, but a permanent fix is still required.
+
+### Testing
+
+* ✅ **Unit Testing:** Miguel continued the implementation and refinement of unit tests.
+
+---
+
+## Team Building
+
+### Escape Room
+
+* **Activity:** The entire team, along with two guests, participated in an escape room challenge.
+* **Outcome:** Successfully completed the game, enhancing team communication and problem-solving dynamics under pressure.
+
+---
+
+## Challenges
+
+### QML Deployment Stagnation
+
+* **Problem:** QML file changes are not reflected in the deployed application unless the bitbake cache is cleared.
+* **Who:** Melanie, Gaspar
+* **Impact:** High - Slows down UI development iteration speed significantly.
+* **Solution:** Currently using forced recompilation/cache clearing (`bitbake -f -c compile` or similar) while investigating the root cause in the recipe configuration.
+
+---
+
+[← Previous Day](2026-02-10.md) | [Next Day →](2026-02-12.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #465

## Type of change

* [x] docs: Documentation only changes

## Summary

Added daily standup log for Wednesday, February 11, 2026 (Day 78). The log documents team activities including battery voltage sensor integration, hardware soldering, ongoing Qt deployment troubleshooting (specifically regarding QML cache), and a team building event.

Key highlights:

* Hugo created code for Raspberry Pi 5 battery voltage monitoring
* Bernardo focused on hardware soldering and external presentation
* Melanie and Gaspar investigated QML deployment issues (cache workaround found)
* Miguel worked on unit tests
* Team completed an escape room challenge

## How to test / Validation

1. Review the daily log file: `docs/standups/2026-02-11.md`
2. Verify it follows the daily log template structure
3. Check that all team members have progress updates
4. Confirm navigation links to previous day (2026-02-10) and next day (2026-02-12)
5. Validate that challenges (QML Deployment) are properly documented

## Checklist

* [x] I have run the project tests locally and they pass
* [x] CI checks are green for this branch (or I will fix any failures)
* [x] I have added or updated tests where applicable
* [x] I have updated documentation (if applicable)
* [x] I have added/updated any migration notes (if database or protocol changes)
* [x] I have requested appropriate reviewers and added labels if needed
* [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility

None.

## Related / dependent PRs

None.

---

**Approval:** Requires a minimum of **1** approval (daily log).
**Action:** The feature branch **MUST** be deleted upon successful merge.

---