### PR TITLE
docs: add daily log for March 4, 2026 (Day 88)

### DIFF
--- a/docs/standups/2026-03-04.md
+++ b/docs/standups/2026-03-04.md
@@ -1,0 +1,87 @@
+# Day 88 - SEAME Automotive Journey
+
+**Date:** Wednesday, March 4, 2026
+
+**Team:** Afonso, Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team pushed forward on multiple fronts: Afonso reorganized the Qt application and delivered a spike on autonomous navigation training methods to guide the team's next decisions. Melanie unblocked part of the AGL multimedia stack but hit a GStreamer decoder blocker. Hugo added a camera integration video and continued PID work, while Bernardo and Miguel spent the day battling unresolved merge conflicts on the emergency brake logic.
+
+---
+
+## Team Progress
+
+### Afonso - Qt Development
+- ✅ Reorganized and refactored the Qt application structure
+- ✅ Prepared and presented spike on Training Methods for Autonomous Navigation (Imitation Learning, Reinforcement Learning, Dataset Aggregation)
+
+### Bernardo - Hardware Integration & Testing
+- 🔄 Attempting to resolve merge conflicts on tests and emergency brake logic — no success yet
+
+### Gaspar - OS & Development Environment
+- ✅ Validated the camera setup issue by pinpointing a PR from the official Yocto/Raspberry Pi repository containing the setup guide and referencing it on the tracking issue
+
+### Hugo - Hardware & Fabrication
+- ✅ Added video demonstrating camera integration to the repository
+- 🔄 Continuing PID control markdown documentation
+- 🔄 Elaborating a proposal for integrating PID control into the codebase
+
+### Melanie - GUI & Team Coordination
+- ✅ Successfully installed missing PulseAudio plugins on AGL
+- 🔄 Investigating decoder issue — `gstreamer1.0-plugins-good-mpg123` not functioning; decoder unable to stream media
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Prepared markdown documenting autonomous navigation model comparisons
+- 🔄 Attempting to fix merge conflicts on tests and emergency brake logic — no success yet
+
+---
+
+## Hardware
+
+### Camera Integration (Hugo)
+- Added a video showcasing camera integration progress to the repository
+
+---
+
+## Software
+
+**Progress:**
+- ✅ **Qt App Refactoring:** Qt application reorganized and refactored (Afonso)
+- ✅ **Autonomous Navigation Spike:** Spike on Imitation Learning, Reinforcement Learning, and Dataset Aggregation prepared and presented (Afonso)
+- ✅ **PulseAudio on AGL:** Missing PulseAudio plugins successfully installed (Melanie)
+- ✅ **Camera Setup Validated:** Official Yocto/Raspberry Pi PR linked on tracking issue (Gaspar)
+- ✅ **Model Presentation Markdown:** Markdown prepared for navigation model comparison (Miguel)
+- 🔄 **AGL Media Decoder:** `gstreamer1.0-plugins-good-mpg123` not working; media streaming blocked (Melanie)
+- 🔄 **Emergency Brake Merge Conflicts:** Merge conflicts on tests and emergency brake logic remain unresolved (Bernardo, Miguel)
+- 🔄 **PID Documentation & Integration Proposal:** PID markdown and code integration proposal in progress (Hugo)
+
+---
+
+## Challenges
+
+| Problem | Who | Impact | Solution |
+|---------|-----|--------|----------|
+| `gstreamer1.0-plugins-good-mpg123` decoder not working on AGL | Melanie | High | Investigation ongoing; media streaming still blocked |
+| Merge conflicts on tests and emergency brake logic | Bernardo, Miguel | High | Multiple attempts made; unresolved — continuing next session |
+
+---
+
+## Decisions
+
+- **Autonomous Navigation Training Approach:** Afonso's spike will inform the team's choice of training method going forward.
+
+---
+
+## Standards & Research
+
+- **Spike — Training Methods for Autonomous Navigation (Afonso):**
+  - *Imitation Learning:* Learns from expert demonstrations; fast to bootstrap but limited by dataset quality.
+  - *Reinforcement Learning:* Learns through reward signals; highly flexible but complex to tune.
+  - *Dataset Aggregation (DAgger):* Iteratively improves imitation learning with corrective data; balances simplicity and robustness.
+
+---
+
+**Previous:** [2026-03-03.md](2026-03-03.md) | **Next:** [2026-03-05.md](2026-03-05.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #520

## Type of change
- [x] docs: Documentation only changes

## Summary
Adds the daily standup log for Wednesday, March 4, 2026 (Day 88). Covers Qt app refactoring and autonomous navigation training spike (Afonso), AGL PulseAudio progress and decoder blocker (Melanie), camera setup validation (Gaspar), camera integration video and PID work (Hugo), and ongoing emergency brake merge conflict efforts (Bernardo, Miguel).

## How to test / Validation
Review the new file at `docs/standups/2026-03-04.md` for completeness and accuracy against the day's activities.

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approval (daily log).
**Action:** The feature branch **MUST** be deleted upon successful merge.