### PR TITLE
feat: Map remote controller input to speed commands sent to STM32

### DIFF
--- a/meta-cross/recipes-rust/controller/files/controller/src/main.rs
+++ b/meta-cross/recipes-rust/controller/files/controller/src/main.rs
@@ -10,7 +10,7 @@ use std::{thread, time::Duration};
 /* CAN Protocol Constants */
 const CAN_ID_MOTOR: u16 = 44;
 const CAN_ID_SERVO: u16 = 45;
-const CAN_INTERFACE: &str = "vcan0";
+const CAN_INTERFACE: &str = "can1";
 
 /* Motor Constants */
 const MAX_MOTOR_SPEED: f64 = 90.0;
@@ -268,7 +268,7 @@ fn run_manual_mode(gamepad: &mut Gamepad, controller: &MotorController) -> Resul
     let mut prev_servo_angle = 90.0;
     
     // Threshold for detecting meaningful changes
-    const MOTOR_THRESHOLD: f64 = 0.01;  // Only send if change > 10 counts
+    const MOTOR_THRESHOLD: f64 = 5.0;  // Only send if change > 5 counts
     const SERVO_THRESHOLD: f64 = 1.0;   // Only send if change > 1 degree
 
     loop {


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #577

## Type of change
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Maps remote controller input to speed commands sent to STM32. Changed speed unit to hectometers per second (hm/s) for better precision in controller calculations.

## How to test / Validation
1. Verify controller input is properly scaled and mapped to motor speed commands
2. Confirm speed values are correctly interpreted in hm/s units
3. Test motor response with various input values

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None - internal controller protocol change with no external impact.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.
