### PR TITLE
fix(firmware): stabilize INA231 voltage path and SOC mapping (#629)

### DIFF
--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -1,7 +1,7 @@
 /**
   ******************************************************************************
   * @file           : sensors.h
-  * @brief          : Sensor management - HTS221 and INA231
+  * @brief          : Sensor management - HTS221 temperature/humidity sensor
   ******************************************************************************
   */
 
@@ -18,152 +18,110 @@ extern "C" {
 #include "app_threadx.h"
 
 /* Exported types ------------------------------------------------------------*/
-
 /* HTS221 sensor data structure */
 typedef struct
 {
-    float       temperature;    /* Temperature in Celsius */
-    float       humidity;       /* Humidity in percentage */
-    uint32_t    timestamp;      /* Timestamp of last read */
-    uint8_t     data_valid;     /* Data validity flag */
+    float		temperature;      /* Temperature in Celsius */
+    float		humidity;         /* Humidity in percentage */
+    uint32_t	timestamp;     /* Timestamp of last read */
+    uint8_t		data_valid;     /* Data validity flag */
 } HTS221_Data_t;
-
-/* HTS221 Calibration data */
-typedef struct
-{
-    int16_t     H0_T0_out;
-    int16_t     H1_T0_out;
-    int16_t     T0_out;
-    int16_t     T1_out;
-    uint16_t    H0_rh;
-    uint16_t    H1_rh;
-    uint16_t    T0_degC;
-    uint16_t    T1_degC;
-} HTS221_Calibration_t;
 
 /* Battery sensor data structure */
 typedef struct
 {
-    float       voltage;        /* Battery voltage in Volts */
-    uint8_t     percentage;     /* Battery percentage (0-100) */
-    uint32_t    timestamp;      /* Timestamp of last read */
-    uint8_t     data_valid;     /* Data validity flag */
+    float		voltage;          /* Battery voltage in Volts */
+    uint8_t		percentage;     /* Battery percentage (0-100) */
+    uint32_t	timestamp;     /* Timestamp of last read */
+    uint8_t		data_valid;     /* Data validity flag */
 } Battery_Data_t;
 
-/* INA231 detailed telemetry structure */
+/* HTS221 Calibration data */
 typedef struct
 {
-    float       voltage;
-    float       current;
-    float       power;
-    uint8_t     percentage;
-    uint32_t    timestamp;
-    uint8_t     data_valid;
-} INA231_Data_t;
-
+    int16_t 	H0_T0_out;
+    int16_t		H1_T0_out;
+    int16_t		T0_out;
+    int16_t		T1_out;
+    uint16_t	H0_rh;
+    uint16_t	H1_rh;
+    uint16_t	T0_degC;
+    uint16_t	T1_degC;
+} HTS221_Calibration_t;
 
 /* Exported constants --------------------------------------------------------*/
-
-/* ================= HTS221 Definitions ================= */
+/* HTS221 I2C Address */
 #define HTS221_I2C_ADDRESS     0x5F
-#define HTS221_WHO_AM_I_VALUE  0xBC
 
 /* HTS221 Register Addresses */
-#define HTS221_WHO_AM_I        0x0F
-#define HTS221_CTRL_REG1       0x20
-#define HTS221_CTRL_REG2       0x21
+#define HTS221_WHO_AM_I 	   0x0F
+#define HTS221_CTRL_REG1	   0x20
+#define HTS221_CTRL_REG2	   0x21
 #define HTS221_CTRL_REG3       0x22
-#define HTS221_STATUS_REG      0x27
+#define HTS221_STATUS_REG	   0x27
 #define HTS221_HUMIDITY_OUT_L  0x28
 #define HTS221_HUMIDITY_OUT_H  0x29
 #define HTS221_TEMP_OUT_L      0x2A
 #define HTS221_TEMP_OUT_H      0x2B
 
 /* HTS221 Calibration registers */
-#define HTS221_H0_RH_X2        0x30
-#define HTS221_H1_RH_X2        0x31
-#define HTS221_T0_DEGC_X8      0x32
-#define HTS221_T1_DEGC_X8      0x33
-#define HTS221_T1_T0_MSB       0x35
-#define HTS221_H0_T0_OUT_L     0x36
-#define HTS221_H1_T0_OUT_H     0x39
-#define HTS221_T0_OUT_L        0x3C
-#define HTS221_T0_OUT_H        0x3D
-#define HTS221_T1_OUT_L        0x3E
+#define HTS221_H0_RH_X2     	0x30
+#define HTS221_H1_RH_X2     	0x31
+#define HTS221_T0_DEGC_X8  		0x32
+#define HTS221_T1_DEGC_X8 		0x33
+#define HTS221_T1_T0_MSB    	0x35
+#define HTS221_H0_T0_OUT_L  	0x36
 
+/* HTS221 Expected WHO_AM_I value */
+#define HTS221_WHO_AM_I_VALUE  	0xBC
 
-/* ================= Battery / INA231 Definitions ================= */
-/* I2C Address for the INA231 monitor connected to 2S2P battery pack */
-/* Hardware: I2C2 STMod+ connector (PH4=SCL pin 7, PH5=SDA pin 10), A0=GND, A1=GND → address 0x40 */
-#define INA231_I2C_ADDRESS     0x40
-#define BATTERY_I2C_ADDRESS    INA231_I2C_ADDRESS
+/* Battery Monitor - INA219 Power Monitor at 0x41 */
+#define BATTERY_I2C_ADDRESS    	0x41
+#define INA219_REG_CONFIG      	0x00
+#define INA219_REG_SHUNT_V     	0x01
+#define INA219_REG_BUS_V       	0x02
+#define INA219_REG_POWER       	0x03
+#define INA219_REG_CURRENT     	0x04
+#define INA219_REG_CALIBRATION 	0x05
 
-/* INA231 Registers */
-#define INA231_REG_CONFIG      0x00
-#define INA231_REG_SHUNT_V     0x01
-#define INA231_REG_BUS_V       0x02
-#define INA231_REG_POWER       0x03
-#define INA231_REG_CURRENT     0x04
-#define INA231_REG_CALIBRATION 0x05
+/* INA219 Bus Voltage Register bits */
+#define INA219_BUS_V_OVF       	(1 << 0)
+#define INA219_BUS_V_CNVR      	(1 << 1)
 
-/* INA231 Configuration & Calibration (R_shunt = 0.100 Ohm, R100) */
-#define INA231_I_LSB           0.000305f   /* A/bit */
-#define INA231_CONFIG_VAL      0x4127u     /* 1024 averages, 1.1 ms conversion */
-#define INA231_CALIB_VAL       168u        /* Cal = 0.00512 / (0.000305 * 0.100) = 168 */
+/* 3S LiPo Battery voltage thresholds */
+#define BATTERY_3S_MAX_V       	12.6f
+#define BATTERY_3S_NOM_V       	11.1f
+#define BATTERY_3S_MIN_V       	9.0f
+#define BATTERY_3S_LOW_V       	10.5f
 
-/* 2S2P Li-Ion Battery voltage thresholds (4.2V max per cell) */
-#define BATTERY_2S_MAX_V       8.4f
-#define BATTERY_2S_NOM_V       7.4f
-#define BATTERY_2S_MIN_V       6.0f
-
-/* 3S Li-Ion battery thresholds used by expansion-board monitor (0x200). */
-#define BATTERY_3S_MAX_V       12.6f
-#define BATTERY_3S_NOM_V       11.1f
-#define BATTERY_3S_MIN_V       9.0f
+#define HTS221_H1_T0_OUT_H  	0x39
+#define HTS221_T0_OUT_L     	0x3C
+#define HTS221_T0_OUT_H    		0x3D
+#define HTS221_T1_OUT_L     	0x3E
 
 #define BATTERY_VOLTAGE_EPSILON 0.01f
 
-/* RPi 5V rail thresholds for percentage (If mapping 5V rail health) */
-#define INA231_VBUS_MIN        4.5f        /* 0%  */
-#define INA231_VBUS_MAX        5.5f        /* 100% */
-#define INA231_VOLTAGE_EPSILON 0.01f
 
+extern TX_MUTEX 			g_sensorDataMutex;
+extern HTS221_Data_t		g_hts221_data;
+extern Battery_Data_t		g_battery_data;
+extern I2C_HandleTypeDef	hi2c2;
 
-/* Exported Variables --------------------------------------------------------*/
-extern TX_MUTEX             g_sensorDataMutex;
-extern HTS221_Data_t        g_hts221_data;
-extern Battery_Data_t       g_battery_data;
-extern INA231_Data_t        g_ina231_data;
-extern I2C_HandleTypeDef    hi2c2;
+/* Global sensor data */
 
-/* Exported Functions --------------------------------------------------------*/
+HAL_StatusTypeDef	HTS221_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef	HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
 
-/* HTS221 Functions */
-HAL_StatusTypeDef   HTS221_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
-void                SensorHTS221Thread(ULONG initial_input);
+HAL_StatusTypeDef	Battery_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef	Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
 
-/* Battery Tracking Functions (Using INA231) */
-HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-void                SensorBatteryThread(ULONG initial_input);
+void 				SensorHTS221Thread(ULONG initial_input);
+void				SensorBatteryThread(ULONG initial_input);
 
-/* Battery / INA231 Functions */
-HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-HAL_StatusTypeDef   Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
-void                SensorBatteryThread(ULONG initial_input);
-
-/* Direct INA231 Functions */
-HAL_StatusTypeDef   INA231_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   INA231_Read(I2C_HandleTypeDef *hi2c, float *voltage, float *current_a, float *power_w, uint8_t *percentage);
-void                SensorINA231Thread(ULONG initial_input);
-
-/* Global Sensor Init */
-void                SensorsInit(void);
+void				SensorsInit(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __SENSORS_H */
+#endif

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -16,6 +16,8 @@ extern "C" {
 #include "stm32u5xx_hal.h"
 #include "tx_api.h"
 #include "app_threadx.h"
+#include <string.h>
+#include <math.h>
 
 /* Exported types ------------------------------------------------------------*/
 /* HTS221 sensor data structure */

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
- * sensors.h
- * Sensor management - HTS221 temperature/humidity sensor and Battery monitoring
+ * @file           : sensors.h
+ * @brief          : Sensor management - HTS221 temperature/humidity sensor and Battery monitoring
  ******************************************************************************
  */
 

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -115,11 +115,12 @@ typedef struct
 } INA231_Data_t;
 
 /* Global sensor data declarations -------------------------------------------*/
-extern TX_MUTEX             g_sensorDataMutex;
-extern HTS221_Data_t        g_hts221Data;
-extern Battery_Data_t       g_batteryData;
-extern I2C_HandleTypeDef    g_hi2c2;
-extern INA231_Data_t        g_ina231Data;
+TX_MUTEX             g_sensorDataMutex;
+HTS221_Data_t        g_hts221Data;
+Battery_Data_t       g_batteryData;
+I2C_HandleTypeDef    g_hi2c2;
+INA231_Data_t        g_ina231Data;
+TX_MUTEX                    g_i2cMutex; 
 
 /* Exported functions --------------------------------------------------------*/
 void                SensorsInit(void);
@@ -134,6 +135,10 @@ HAL_StatusTypeDef   BatteryReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
 void                SensorHts221Thread(ULONG initial_input);
 void                SensorBatteryThread(ULONG initial_input);
 void                SensorIna231Thread(ULONG initial_input);
+
+extern void UartPrint(const char* msg);
+extern void UartPrintf(const char* format, ...);
+extern void SoftwareDelay(uint32_t ms);
 
 #ifdef __cplusplus
 }

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -1,7 +1,7 @@
 /**
   ******************************************************************************
   * @file           : sensors.h
-  * @brief          : Sensor management - HTS221 temperature/humidity sensor
+  * @brief          : Sensor management - HTS221 and INA231
   ******************************************************************************
   */
 
@@ -18,110 +18,152 @@ extern "C" {
 #include "app_threadx.h"
 
 /* Exported types ------------------------------------------------------------*/
+
 /* HTS221 sensor data structure */
 typedef struct
 {
-    float		temperature;      /* Temperature in Celsius */
-    float		humidity;         /* Humidity in percentage */
-    uint32_t	timestamp;     /* Timestamp of last read */
-    uint8_t		data_valid;     /* Data validity flag */
+    float       temperature;    /* Temperature in Celsius */
+    float       humidity;       /* Humidity in percentage */
+    uint32_t    timestamp;      /* Timestamp of last read */
+    uint8_t     data_valid;     /* Data validity flag */
 } HTS221_Data_t;
-
-/* Battery sensor data structure */
-typedef struct
-{
-    float		voltage;          /* Battery voltage in Volts */
-    uint8_t		percentage;     /* Battery percentage (0-100) */
-    uint32_t	timestamp;     /* Timestamp of last read */
-    uint8_t		data_valid;     /* Data validity flag */
-} Battery_Data_t;
 
 /* HTS221 Calibration data */
 typedef struct
 {
-    int16_t 	H0_T0_out;
-    int16_t		H1_T0_out;
-    int16_t		T0_out;
-    int16_t		T1_out;
-    uint16_t	H0_rh;
-    uint16_t	H1_rh;
-    uint16_t	T0_degC;
-    uint16_t	T1_degC;
+    int16_t     H0_T0_out;
+    int16_t     H1_T0_out;
+    int16_t     T0_out;
+    int16_t     T1_out;
+    uint16_t    H0_rh;
+    uint16_t    H1_rh;
+    uint16_t    T0_degC;
+    uint16_t    T1_degC;
 } HTS221_Calibration_t;
 
+/* Battery sensor data structure */
+typedef struct
+{
+    float       voltage;        /* Battery voltage in Volts */
+    uint8_t     percentage;     /* Battery percentage (0-100) */
+    uint32_t    timestamp;      /* Timestamp of last read */
+    uint8_t     data_valid;     /* Data validity flag */
+} Battery_Data_t;
+
+/* INA231 detailed telemetry structure */
+typedef struct
+{
+    float       voltage;
+    float       current;
+    float       power;
+    uint8_t     percentage;
+    uint32_t    timestamp;
+    uint8_t     data_valid;
+} INA231_Data_t;
+
+
 /* Exported constants --------------------------------------------------------*/
-/* HTS221 I2C Address */
+
+/* ================= HTS221 Definitions ================= */
 #define HTS221_I2C_ADDRESS     0x5F
+#define HTS221_WHO_AM_I_VALUE  0xBC
 
 /* HTS221 Register Addresses */
-#define HTS221_WHO_AM_I 	   0x0F
-#define HTS221_CTRL_REG1	   0x20
-#define HTS221_CTRL_REG2	   0x21
+#define HTS221_WHO_AM_I        0x0F
+#define HTS221_CTRL_REG1       0x20
+#define HTS221_CTRL_REG2       0x21
 #define HTS221_CTRL_REG3       0x22
-#define HTS221_STATUS_REG	   0x27
+#define HTS221_STATUS_REG      0x27
 #define HTS221_HUMIDITY_OUT_L  0x28
 #define HTS221_HUMIDITY_OUT_H  0x29
 #define HTS221_TEMP_OUT_L      0x2A
 #define HTS221_TEMP_OUT_H      0x2B
 
 /* HTS221 Calibration registers */
-#define HTS221_H0_RH_X2     	0x30
-#define HTS221_H1_RH_X2     	0x31
-#define HTS221_T0_DEGC_X8  		0x32
-#define HTS221_T1_DEGC_X8 		0x33
-#define HTS221_T1_T0_MSB    	0x35
-#define HTS221_H0_T0_OUT_L  	0x36
+#define HTS221_H0_RH_X2        0x30
+#define HTS221_H1_RH_X2        0x31
+#define HTS221_T0_DEGC_X8      0x32
+#define HTS221_T1_DEGC_X8      0x33
+#define HTS221_T1_T0_MSB       0x35
+#define HTS221_H0_T0_OUT_L     0x36
+#define HTS221_H1_T0_OUT_H     0x39
+#define HTS221_T0_OUT_L        0x3C
+#define HTS221_T0_OUT_H        0x3D
+#define HTS221_T1_OUT_L        0x3E
 
-/* HTS221 Expected WHO_AM_I value */
-#define HTS221_WHO_AM_I_VALUE  	0xBC
 
-/* Battery Monitor - INA219 Power Monitor at 0x41 */
-#define BATTERY_I2C_ADDRESS    	0x41
-#define INA219_REG_CONFIG      	0x00
-#define INA219_REG_SHUNT_V     	0x01
-#define INA219_REG_BUS_V       	0x02
-#define INA219_REG_POWER       	0x03
-#define INA219_REG_CURRENT     	0x04
-#define INA219_REG_CALIBRATION 	0x05
+/* ================= Battery / INA231 Definitions ================= */
+/* I2C Address for the INA231 monitor connected to 2S2P battery pack */
+/* Hardware: I2C2 STMod+ connector (PH4=SCL pin 7, PH5=SDA pin 10), A0=GND, A1=GND → address 0x40 */
+#define INA231_I2C_ADDRESS     0x40
+#define BATTERY_I2C_ADDRESS    INA231_I2C_ADDRESS
 
-/* INA219 Bus Voltage Register bits */
-#define INA219_BUS_V_OVF       	(1 << 0)
-#define INA219_BUS_V_CNVR      	(1 << 1)
+/* INA231 Registers */
+#define INA231_REG_CONFIG      0x00
+#define INA231_REG_SHUNT_V     0x01
+#define INA231_REG_BUS_V       0x02
+#define INA231_REG_POWER       0x03
+#define INA231_REG_CURRENT     0x04
+#define INA231_REG_CALIBRATION 0x05
 
-/* 3S LiPo Battery voltage thresholds */
-#define BATTERY_3S_MAX_V       	12.6f
-#define BATTERY_3S_NOM_V       	11.1f
-#define BATTERY_3S_MIN_V       	9.0f
-#define BATTERY_3S_LOW_V       	10.5f
+/* INA231 Configuration & Calibration (R_shunt = 0.100 Ohm, R100) */
+#define INA231_I_LSB           0.000305f   /* A/bit */
+#define INA231_CONFIG_VAL      0x4127u     /* 1024 averages, 1.1 ms conversion */
+#define INA231_CALIB_VAL       168u        /* Cal = 0.00512 / (0.000305 * 0.100) = 168 */
 
-#define HTS221_H1_T0_OUT_H  	0x39
-#define HTS221_T0_OUT_L     	0x3C
-#define HTS221_T0_OUT_H    		0x3D
-#define HTS221_T1_OUT_L     	0x3E
+/* 2S2P Li-Ion Battery voltage thresholds (4.2V max per cell) */
+#define BATTERY_2S_MAX_V       8.4f
+#define BATTERY_2S_NOM_V       7.4f
+#define BATTERY_2S_MIN_V       6.0f
+
+/* 3S Li-Ion battery thresholds used by expansion-board monitor (0x200). */
+#define BATTERY_3S_MAX_V       12.6f
+#define BATTERY_3S_NOM_V       11.1f
+#define BATTERY_3S_MIN_V       9.0f
 
 #define BATTERY_VOLTAGE_EPSILON 0.01f
 
+/* RPi 5V rail thresholds for percentage (If mapping 5V rail health) */
+#define INA231_VBUS_MIN        4.5f        /* 0%  */
+#define INA231_VBUS_MAX        5.5f        /* 100% */
+#define INA231_VOLTAGE_EPSILON 0.01f
 
-extern TX_MUTEX 			g_sensorDataMutex;
-extern HTS221_Data_t		g_hts221_data;
-extern Battery_Data_t		g_battery_data;
-extern I2C_HandleTypeDef	hi2c2;
 
-/* Global sensor data */
+/* Exported Variables --------------------------------------------------------*/
+extern TX_MUTEX             g_sensorDataMutex;
+extern HTS221_Data_t        g_hts221_data;
+extern Battery_Data_t       g_battery_data;
+extern INA231_Data_t        g_ina231_data;
+extern I2C_HandleTypeDef    hi2c2;
 
-HAL_StatusTypeDef	HTS221_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef	HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
+/* Exported Functions --------------------------------------------------------*/
 
-HAL_StatusTypeDef	Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef	Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+/* HTS221 Functions */
+HAL_StatusTypeDef   HTS221_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
+void                SensorHTS221Thread(ULONG initial_input);
 
-void 				SensorHTS221Thread(ULONG initial_input);
-void				SensorBatteryThread(ULONG initial_input);
+/* Battery Tracking Functions (Using INA231) */
+HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+void                SensorBatteryThread(ULONG initial_input);
 
-void				SensorsInit(void);
+/* Battery / INA231 Functions */
+HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+HAL_StatusTypeDef   Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
+void                SensorBatteryThread(ULONG initial_input);
+
+/* Direct INA231 Functions */
+HAL_StatusTypeDef   INA231_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   INA231_Read(I2C_HandleTypeDef *hi2c, float *voltage, float *current_a, float *power_w, uint8_t *percentage);
+void                SensorINA231Thread(ULONG initial_input);
+
+/* Global Sensor Init */
+void                SensorsInit(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __SENSORS_H */

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -16,8 +16,6 @@ extern "C" {
 #include "stm32u5xx_hal.h"
 #include "tx_api.h"
 #include "app_threadx.h"
-#include <string.h>
-#include <math.h>
 
 /* Exported constants --------------------------------------------------------*/
 /* HTS221 I2C Address */

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -70,6 +70,9 @@ extern "C" {
 
 #define BATTERY_VOLTAGE_EPSILON 0.01f
 
+/* INA231 I2C Address */
+#define INA231_I2C_ADDRESS     0x40
+
 /* Exported types ------------------------------------------------------------*/
 /* HTS221 sensor data structure */
 typedef struct
@@ -102,11 +105,23 @@ typedef struct
     uint16_t    T1_degC;
 } HTS221_Calibration_t;
 
+/* INA231 specific sensor data structure */
+typedef struct
+{
+    float       voltage;
+    float       current;
+    float       power;
+    uint8_t     percentage;
+    uint32_t    timestamp;
+    uint8_t     data_valid;
+} INA231_Data_t;
+
 /* Global sensor data declarations -------------------------------------------*/
 extern TX_MUTEX             g_sensorDataMutex;
 extern HTS221_Data_t        g_hts221_data;
 extern Battery_Data_t       g_battery_data;
 extern I2C_HandleTypeDef    hi2c2;
+extern INA231_Data_t        g_ina231_data;
 
 /* Exported functions --------------------------------------------------------*/
 void                SensorsInit(void);

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -120,7 +120,7 @@ HTS221_Data_t        g_hts221Data;
 Battery_Data_t       g_batteryData;
 I2C_HandleTypeDef    g_hi2c2;
 INA231_Data_t        g_ina231Data;
-TX_MUTEX                    g_i2cMutex; 
+TX_MUTEX             g_i2cMutex; 
 
 /* Exported functions --------------------------------------------------------*/
 void                SensorsInit(void);

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -118,24 +118,24 @@ typedef struct
 
 /* Global sensor data declarations -------------------------------------------*/
 extern TX_MUTEX             g_sensorDataMutex;
-extern HTS221_Data_t        g_hts221_data;
-extern Battery_Data_t       g_battery_data;
-extern I2C_HandleTypeDef    hi2c2;
-extern INA231_Data_t        g_ina231_data;
+extern HTS221_Data_t        g_hts221Data;
+extern Battery_Data_t       g_batteryData;
+extern I2C_HandleTypeDef    g_hi2c2;
+extern INA231_Data_t        g_ina231Data;
 
 /* Exported functions --------------------------------------------------------*/
 void                SensorsInit(void);
 
-HAL_StatusTypeDef   HTS221_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
+HAL_StatusTypeDef   Hts221Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   Hts221ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
 
-HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-HAL_StatusTypeDef   Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
+HAL_StatusTypeDef   BatteryInit(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   BatteryRead(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+HAL_StatusTypeDef   BatteryReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
 
-void                SensorHTS221Thread(ULONG initial_input);
+void                SensorHts221Thread(ULONG initial_input);
 void                SensorBatteryThread(ULONG initial_input);
-void                SensorINA231Thread(ULONG initial_input);
+void                SensorIna231Thread(ULONG initial_input);
 
 #ifdef __cplusplus
 }

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -1,8 +1,7 @@
 /*
  ******************************************************************************
  * sensors.h
- * Sensor management and definitions for HTS221 and INA231/219.
- * Provides public interfaces and data structures for RTOS-based sensor management.
+ * Sensor management - HTS221 temperature/humidity sensor and Battery monitoring
  ******************************************************************************
  */
 
@@ -21,88 +20,76 @@ extern "C" {
 #include <math.h>
 
 /* Exported constants --------------------------------------------------------*/
-
-/* HTS221 I2C Configuration */
-#define HTS221_I2C_ADDRESS         0x5F
-#define HTS221_WHO_AM_I_VALUE      0xBC
+/* HTS221 I2C Address */
+#define HTS221_I2C_ADDRESS     0x5F
 
 /* HTS221 Register Addresses */
-#define HTS221_WHO_AM_I            0x0F
-#define HTS221_CTRL_REG1           0x20
-#define HTS221_CTRL_REG2           0x21
-#define HTS221_CTRL_REG3           0x22
-#define HTS221_STATUS_REG          0x27
-#define HTS221_HUMIDITY_OUT_L      0x28
-#define HTS221_HUMIDITY_OUT_H      0x29
-#define HTS221_TEMP_OUT_L          0x2A
-#define HTS221_TEMP_OUT_H          0x2B
+#define HTS221_WHO_AM_I        0x0F
+#define HTS221_CTRL_REG1       0x20
+#define HTS221_CTRL_REG2       0x21
+#define HTS221_CTRL_REG3       0x22
+#define HTS221_STATUS_REG      0x27
+#define HTS221_HUMIDITY_OUT_L  0x28
+#define HTS221_HUMIDITY_OUT_H  0x29
+#define HTS221_TEMP_OUT_L      0x2A
+#define HTS221_TEMP_OUT_H      0x2B
 
-/* HTS221 Calibration Registers */
-#define HTS221_H0_RH_X2            0x30
-#define HTS221_H1_RH_X2            0x31
-#define HTS221_T0_DEGC_X8          0x32
-#define HTS221_T1_DEGC_X8          0x33
-#define HTS221_T1_T0_MSB           0x35
-#define HTS221_H0_T0_OUT_L         0x36
-#define HTS221_H1_T0_OUT_H         0x39
-#define HTS221_T0_OUT_L            0x3C
-#define HTS221_T0_OUT_H            0x3D
-#define HTS221_T1_OUT_L            0x3E
+/* HTS221 Calibration registers */
+#define HTS221_H0_RH_X2        0x30
+#define HTS221_H1_RH_X2        0x31
+#define HTS221_T0_DEGC_X8      0x32
+#define HTS221_T1_DEGC_X8      0x33
+#define HTS221_T1_T0_MSB       0x35
+#define HTS221_H0_T0_OUT_L     0x36
+#define HTS221_H1_T0_OUT_H     0x39
+#define HTS221_T0_OUT_L        0x3C
+#define HTS221_T0_OUT_H        0x3D
+#define HTS221_T1_OUT_L        0x3E
 
-/* Battery Monitor (INA219/INA231) Configuration */
-#define BATTERY_I2C_ADDRESS        0x41
-#define INA219_REG_CONFIG          0x00
-#define INA219_REG_SHUNT_V         0x01
-#define INA219_REG_BUS_V           0x02
-#define INA219_REG_POWER           0x03
-#define INA219_REG_CURRENT         0x04
-#define INA219_REG_CALIBRATION     0x05
+/* HTS221 Expected WHO_AM_I value */
+#define HTS221_WHO_AM_I_VALUE  0xBC
 
-/* INA219 Bus Voltage Register Bits */
-#define INA219_BUS_V_OVF           (1 << 0)
-#define INA219_BUS_V_CNVR          (1 << 1)
+/* Battery Monitor - INA219 Power Monitor at 0x41 */
+#define BATTERY_I2C_ADDRESS    0x41
+#define INA219_REG_CONFIG      0x00
+#define INA219_REG_SHUNT_V     0x01
+#define INA219_REG_BUS_V       0x02
+#define INA219_REG_POWER       0x03
+#define INA219_REG_CURRENT     0x04
+#define INA219_REG_CALIBRATION 0x05
 
-/* Battery Voltage Thresholds (3S LiPo) */
-#define BATTERY_3S_MAX_V           12.6f
-#define BATTERY_3S_NOM_V           11.1f
-#define BATTERY_3S_MIN_V           9.0f
-#define BATTERY_3S_LOW_V           10.5f
+/* INA219 Bus Voltage Register bits */
+#define INA219_BUS_V_OVF       (1 << 0)
+#define INA219_BUS_V_CNVR      (1 << 1)
 
-/* Epsilon for battery voltage comparisons */
-#define BATTERY_VOLTAGE_EPSILON    0.01f
+/* 3S LiPo Battery voltage thresholds */
+#define BATTERY_3S_MAX_V       12.6f
+#define BATTERY_3S_NOM_V       11.1f
+#define BATTERY_3S_MIN_V       9.0f
+#define BATTERY_3S_LOW_V       10.5f
+
+#define BATTERY_VOLTAGE_EPSILON 0.01f
 
 /* Exported types ------------------------------------------------------------*/
-
 /* HTS221 sensor data structure */
 typedef struct
 {
-    float       temperature;       
-    float       humidity;          
-    uint32_t    timestamp;         
-    uint8_t     data_valid;        
+    float       temperature;      /* Temperature in Celsius */
+    float       humidity;         /* Humidity in percentage */
+    uint32_t    timestamp;        /* Timestamp of last read */
+    uint8_t     data_valid;       /* Data validity flag */
 } HTS221_Data_t;
 
-/* Generic Battery sensor data structure */
+/* Battery sensor data structure */
 typedef struct
 {
-    float       voltage;           
-    uint8_t     percentage;        
-    uint32_t    timestamp;         
-    uint8_t     data_valid;        
+    float       voltage;          /* Battery voltage in Volts */
+    uint8_t     percentage;       /* Battery percentage (0-100) */
+    uint32_t    timestamp;        /* Timestamp of last read */
+    uint8_t     data_valid;       /* Data validity flag */
 } Battery_Data_t;
 
-/* INA231 specific sensor data structure */
-typedef struct
-{
-    float       voltage;           
-    float       current;           
-    float       power;             
-    uint8_t     percentage;        
-    uint32_t    timestamp;         
-    uint8_t     data_valid;        
-} INA231_Data_t;
-
-/* HTS221 Factory calibration data structure */
+/* HTS221 Calibration data */
 typedef struct
 {
     int16_t     H0_T0_out;
@@ -115,28 +102,28 @@ typedef struct
     uint16_t    T1_degC;
 } HTS221_Calibration_t;
 
-/* Global variables ----------------------------------------------------------*/
-extern TX_MUTEX          g_sensorDataMutex;
-extern HTS221_Data_t     g_hts221_data;
-extern Battery_Data_t    g_battery_data;
-extern INA231_Data_t     g_ina231_data;
-extern I2C_HandleTypeDef hi2c2;
+/* Global sensor data declarations -------------------------------------------*/
+extern TX_MUTEX             g_sensorDataMutex;
+extern HTS221_Data_t        g_hts221_data;
+extern Battery_Data_t       g_battery_data;
+extern I2C_HandleTypeDef    hi2c2;
 
 /* Exported functions --------------------------------------------------------*/
+void                SensorsInit(void);
 
-void SensorsInit(void);
-HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
-HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
+HAL_StatusTypeDef   HTS221_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
 
-void SensorHTS221Thread(ULONG initial_input);
-void SensorBatteryThread(ULONG initial_input);
-void SensorINA231Thread(ULONG initial_input);
+HAL_StatusTypeDef   Battery_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef   Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+HAL_StatusTypeDef   Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
+
+void                SensorHTS221Thread(ULONG initial_input);
+void                SensorBatteryThread(ULONG initial_input);
+void                SensorINA231Thread(ULONG initial_input);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __SENSORS_H */
+#endif

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -115,12 +115,12 @@ typedef struct
 } INA231_Data_t;
 
 /* Global sensor data declarations -------------------------------------------*/
-TX_MUTEX             g_sensorDataMutex;
-HTS221_Data_t        g_hts221Data;
-Battery_Data_t       g_batteryData;
-I2C_HandleTypeDef    g_hi2c2;
-INA231_Data_t        g_ina231Data;
-TX_MUTEX             g_i2cMutex; 
+extern TX_MUTEX             g_sensorDataMutex;
+extern HTS221_Data_t        g_hts221Data;
+extern Battery_Data_t       g_batteryData;
+extern I2C_HandleTypeDef    g_hi2c2;
+extern INA231_Data_t        g_ina231Data;
+extern TX_MUTEX             g_i2cMutex;
 
 /* Exported functions --------------------------------------------------------*/
 void                SensorsInit(void);

--- a/firmware/Core/Inc/sensors.h
+++ b/firmware/Core/Inc/sensors.h
@@ -1,9 +1,10 @@
-/**
-  ******************************************************************************
-  * @file           : sensors.h
-  * @brief          : Sensor management - HTS221 temperature/humidity sensor
-  ******************************************************************************
-  */
+/*
+ ******************************************************************************
+ * sensors.h
+ * Sensor management and definitions for HTS221 and INA231/219.
+ * Provides public interfaces and data structures for RTOS-based sensor management.
+ ******************************************************************************
+ */
 
 #ifndef __SENSORS_H
 #define __SENSORS_H
@@ -19,111 +20,123 @@ extern "C" {
 #include <string.h>
 #include <math.h>
 
+/* Exported constants --------------------------------------------------------*/
+
+/* HTS221 I2C Configuration */
+#define HTS221_I2C_ADDRESS         0x5F
+#define HTS221_WHO_AM_I_VALUE      0xBC
+
+/* HTS221 Register Addresses */
+#define HTS221_WHO_AM_I            0x0F
+#define HTS221_CTRL_REG1           0x20
+#define HTS221_CTRL_REG2           0x21
+#define HTS221_CTRL_REG3           0x22
+#define HTS221_STATUS_REG          0x27
+#define HTS221_HUMIDITY_OUT_L      0x28
+#define HTS221_HUMIDITY_OUT_H      0x29
+#define HTS221_TEMP_OUT_L          0x2A
+#define HTS221_TEMP_OUT_H          0x2B
+
+/* HTS221 Calibration Registers */
+#define HTS221_H0_RH_X2            0x30
+#define HTS221_H1_RH_X2            0x31
+#define HTS221_T0_DEGC_X8          0x32
+#define HTS221_T1_DEGC_X8          0x33
+#define HTS221_T1_T0_MSB           0x35
+#define HTS221_H0_T0_OUT_L         0x36
+#define HTS221_H1_T0_OUT_H         0x39
+#define HTS221_T0_OUT_L            0x3C
+#define HTS221_T0_OUT_H            0x3D
+#define HTS221_T1_OUT_L            0x3E
+
+/* Battery Monitor (INA219/INA231) Configuration */
+#define BATTERY_I2C_ADDRESS        0x41
+#define INA219_REG_CONFIG          0x00
+#define INA219_REG_SHUNT_V         0x01
+#define INA219_REG_BUS_V           0x02
+#define INA219_REG_POWER           0x03
+#define INA219_REG_CURRENT         0x04
+#define INA219_REG_CALIBRATION     0x05
+
+/* INA219 Bus Voltage Register Bits */
+#define INA219_BUS_V_OVF           (1 << 0)
+#define INA219_BUS_V_CNVR          (1 << 1)
+
+/* Battery Voltage Thresholds (3S LiPo) */
+#define BATTERY_3S_MAX_V           12.6f
+#define BATTERY_3S_NOM_V           11.1f
+#define BATTERY_3S_MIN_V           9.0f
+#define BATTERY_3S_LOW_V           10.5f
+
+/* Epsilon for battery voltage comparisons */
+#define BATTERY_VOLTAGE_EPSILON    0.01f
+
 /* Exported types ------------------------------------------------------------*/
+
 /* HTS221 sensor data structure */
 typedef struct
 {
-    float		temperature;      /* Temperature in Celsius */
-    float		humidity;         /* Humidity in percentage */
-    uint32_t	timestamp;     /* Timestamp of last read */
-    uint8_t		data_valid;     /* Data validity flag */
+    float       temperature;       
+    float       humidity;          
+    uint32_t    timestamp;         
+    uint8_t     data_valid;        
 } HTS221_Data_t;
 
-/* Battery sensor data structure */
+/* Generic Battery sensor data structure */
 typedef struct
 {
-    float		voltage;          /* Battery voltage in Volts */
-    uint8_t		percentage;     /* Battery percentage (0-100) */
-    uint32_t	timestamp;     /* Timestamp of last read */
-    uint8_t		data_valid;     /* Data validity flag */
+    float       voltage;           
+    uint8_t     percentage;        
+    uint32_t    timestamp;         
+    uint8_t     data_valid;        
 } Battery_Data_t;
 
-/* HTS221 Calibration data */
+/* INA231 specific sensor data structure */
 typedef struct
 {
-    int16_t 	H0_T0_out;
-    int16_t		H1_T0_out;
-    int16_t		T0_out;
-    int16_t		T1_out;
-    uint16_t	H0_rh;
-    uint16_t	H1_rh;
-    uint16_t	T0_degC;
-    uint16_t	T1_degC;
+    float       voltage;           
+    float       current;           
+    float       power;             
+    uint8_t     percentage;        
+    uint32_t    timestamp;         
+    uint8_t     data_valid;        
+} INA231_Data_t;
+
+/* HTS221 Factory calibration data structure */
+typedef struct
+{
+    int16_t     H0_T0_out;
+    int16_t     H1_T0_out;
+    int16_t     T0_out;
+    int16_t     T1_out;
+    uint16_t    H0_rh;
+    uint16_t    H1_rh;
+    uint16_t    T0_degC;
+    uint16_t    T1_degC;
 } HTS221_Calibration_t;
 
-/* Exported constants --------------------------------------------------------*/
-/* HTS221 I2C Address */
-#define HTS221_I2C_ADDRESS     0x5F
+/* Global variables ----------------------------------------------------------*/
+extern TX_MUTEX          g_sensorDataMutex;
+extern HTS221_Data_t     g_hts221_data;
+extern Battery_Data_t    g_battery_data;
+extern INA231_Data_t     g_ina231_data;
+extern I2C_HandleTypeDef hi2c2;
 
-/* HTS221 Register Addresses */
-#define HTS221_WHO_AM_I 	   0x0F
-#define HTS221_CTRL_REG1	   0x20
-#define HTS221_CTRL_REG2	   0x21
-#define HTS221_CTRL_REG3       0x22
-#define HTS221_STATUS_REG	   0x27
-#define HTS221_HUMIDITY_OUT_L  0x28
-#define HTS221_HUMIDITY_OUT_H  0x29
-#define HTS221_TEMP_OUT_L      0x2A
-#define HTS221_TEMP_OUT_H      0x2B
+/* Exported functions --------------------------------------------------------*/
 
-/* HTS221 Calibration registers */
-#define HTS221_H0_RH_X2     	0x30
-#define HTS221_H1_RH_X2     	0x31
-#define HTS221_T0_DEGC_X8  		0x32
-#define HTS221_T1_DEGC_X8 		0x33
-#define HTS221_T1_T0_MSB    	0x35
-#define HTS221_H0_T0_OUT_L  	0x36
+void SensorsInit(void);
+HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
+HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current);
 
-/* HTS221 Expected WHO_AM_I value */
-#define HTS221_WHO_AM_I_VALUE  	0xBC
-
-/* Battery Monitor - INA219 Power Monitor at 0x41 */
-#define BATTERY_I2C_ADDRESS    	0x41
-#define INA219_REG_CONFIG      	0x00
-#define INA219_REG_SHUNT_V     	0x01
-#define INA219_REG_BUS_V       	0x02
-#define INA219_REG_POWER       	0x03
-#define INA219_REG_CURRENT     	0x04
-#define INA219_REG_CALIBRATION 	0x05
-
-/* INA219 Bus Voltage Register bits */
-#define INA219_BUS_V_OVF       	(1 << 0)
-#define INA219_BUS_V_CNVR      	(1 << 1)
-
-/* 3S LiPo Battery voltage thresholds */
-#define BATTERY_3S_MAX_V       	12.6f
-#define BATTERY_3S_NOM_V       	11.1f
-#define BATTERY_3S_MIN_V       	9.0f
-#define BATTERY_3S_LOW_V       	10.5f
-
-#define HTS221_H1_T0_OUT_H  	0x39
-#define HTS221_T0_OUT_L     	0x3C
-#define HTS221_T0_OUT_H    		0x3D
-#define HTS221_T1_OUT_L     	0x3E
-
-#define BATTERY_VOLTAGE_EPSILON 0.01f
-
-
-extern TX_MUTEX 			g_sensorDataMutex;
-extern HTS221_Data_t		g_hts221_data;
-extern Battery_Data_t		g_battery_data;
-extern I2C_HandleTypeDef	hi2c2;
-
-/* Global sensor data */
-
-HAL_StatusTypeDef	HTS221_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef	HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity);
-
-HAL_StatusTypeDef	Battery_Init(I2C_HandleTypeDef *hi2c);
-HAL_StatusTypeDef	Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-
-void 				SensorHTS221Thread(ULONG initial_input);
-void				SensorBatteryThread(ULONG initial_input);
-
-void				SensorsInit(void);
+void SensorHTS221Thread(ULONG initial_input);
+void SensorBatteryThread(ULONG initial_input);
+void SensorINA231Thread(ULONG initial_input);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __SENSORS_H */

--- a/firmware/Core/Src/can_tx.c
+++ b/firmware/Core/Src/can_tx.c
@@ -49,6 +49,7 @@ void CraftSpeedMessage(t_can_message *msg, float speed)
 int CanSend(t_can_message* msg)
 {
 	FDCAN_TxHeaderTypeDef tx_header;
+	uint8_t attempt;
 	
 	const uint32_t dlc_map[] = {
 		FDCAN_DLC_BYTES_0,
@@ -71,9 +72,14 @@ int CanSend(t_can_message* msg)
 	tx_header.TxEventFifoControl = FDCAN_NO_TX_EVENTS;
 	tx_header.MessageMarker = 0;
 
-	if (HAL_FDCAN_AddMessageToTxFifoQ(&hfdcan1, &tx_header, (uint8_t*)msg->data) != HAL_OK)
-		return 1;
-	return 0;
+	for (attempt = 0; attempt < 3; ++attempt)
+	{
+		if (HAL_FDCAN_AddMessageToTxFifoQ(&hfdcan1, &tx_header, (uint8_t*)msg->data) == HAL_OK)
+			return 0;
+		tx_thread_sleep(1);
+	}
+	
+	return 1;
 }
 
 /**
@@ -85,19 +91,140 @@ int CanSend(t_can_message* msg)
 VOID CanTx(ULONG initial_input)
 {
 	t_can_message msg;
+	t_can_message batt_msg;
+	t_can_message ina_msg;
+	t_can_message ina_cur_msg;
+	t_can_message hts_msg;
+	uint32_t ina_dbg_count = 0u;
 	ULONG actual_flags;
+	ULONG last_ina_send = tx_time_get();
+	ULONG last_hts_send = tx_time_get();
+	const ULONG ina_send_ticks = 100; /* 1 second @ 100Hz tick */
+	const ULONG hts_send_ticks = 500; /* 5 seconds @ 100Hz tick */
 
 	while (1)
 	{
+		ULONG now = tx_time_get();
 		tx_event_flags_get(&g_eventFlags, FLAG_SENSOR_UPDATE, TX_OR_CLEAR, &actual_flags, TX_NO_WAIT);
 
-		tx_mutex_get(&g_speedDataMutex, TX_WAIT_FOREVER);
-		float speed = g_vehicleSpeed;
-		tx_mutex_put(&g_speedDataMutex);
+		float speed = 0.0f;
+		if (tx_mutex_get(&g_speedDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+		{
+			speed = g_vehicleSpeed;
+			tx_mutex_put(&g_speedDataMutex);
+		}
+		else
+		{
+			tx_thread_sleep(1);
+			continue;
+		}
 
-		tx_mutex_get(&g_canMutex, TX_WAIT_FOREVER);
-		CraftSpeedMessage(&msg, speed);
-		tx_mutex_put(&g_canMutex);
+		if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
+		{
+			CraftSpeedMessage(&msg, speed);
+
+			if ((now - last_ina_send) >= ina_send_ticks)
+			{
+				float stm_voltage = 0.0f;
+				uint8_t stm_percentage = 0xFFu;
+				uint8_t stm_valid = 0u;
+				float voltage = 0.0f;
+				float current = 0.0f;
+				uint8_t percentage = 0xFFu;
+				uint8_t ina_valid = 0u;
+
+				memset(&batt_msg, 0, sizeof(batt_msg));
+				batt_msg.id = CAN_ID_BATTERY_DATA;
+				batt_msg.len = 5;
+
+				memset(&ina_msg, 0, sizeof(ina_msg));
+				ina_msg.id = CAN_ID_INA231_DATA;
+				ina_msg.len = 5;
+
+				memset(&ina_cur_msg, 0, sizeof(ina_cur_msg));
+				ina_cur_msg.id = CAN_ID_INA231_CURRENT;
+				ina_cur_msg.len = 4;
+
+				if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+				{
+					if (g_battery_data.data_valid)
+					{
+						stm_voltage = g_battery_data.voltage;
+						stm_percentage = g_battery_data.percentage;
+						stm_valid = 1u;
+					}
+					if (g_ina231_data.data_valid)
+					{
+						voltage = g_ina231_data.voltage;
+						current = g_ina231_data.current;
+						percentage = g_ina231_data.percentage;
+						ina_valid = 1u;
+					}
+					tx_mutex_put(&g_sensorDataMutex);
+				}
+
+				if (stm_valid)
+				{
+					batt_msg.data[0] = stm_percentage;
+					memcpy(&batt_msg.data[1], &stm_voltage, 4);
+					(void)CanSend(&batt_msg);
+				}
+
+				if (ina_valid)
+				{
+					uint32_t current_bits = 0u;
+					ina_msg.data[0] = percentage;
+					memcpy(&ina_msg.data[1], &voltage, 4);
+					memcpy(&ina_cur_msg.data[0], &current, 4);
+					memcpy(&current_bits, &current, sizeof(current_bits));
+					(void)CanSend(&ina_msg);
+					(void)CanSend(&ina_cur_msg);
+					ina_dbg_count++;
+					if ((ina_dbg_count % 10u) == 0u)
+					{
+						UartPrintf("[CAN 0x211] bits=0x%08lX bytes=%02X %02X %02X %02X\r\n",
+							(unsigned long)current_bits,
+							(unsigned int)ina_cur_msg.data[0],
+							(unsigned int)ina_cur_msg.data[1],
+							(unsigned int)ina_cur_msg.data[2],
+							(unsigned int)ina_cur_msg.data[3]);
+					}
+				}
+				last_ina_send = now;
+			}
+
+			if ((now - last_hts_send) >= hts_send_ticks)
+			{
+				float temperature = 0.0f;
+				float humidity = 0.0f;
+				uint8_t hts_valid = 0u;
+
+				memset(&hts_msg, 0, sizeof(hts_msg));
+				hts_msg.id = CAN_ID_HTS221_DATA;
+				hts_msg.len = 8;
+
+				if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+				{
+					if (g_hts221_data.data_valid)
+					{
+						temperature = g_hts221_data.temperature;
+						humidity = g_hts221_data.humidity;
+						hts_valid = 1u;
+					}
+					tx_mutex_put(&g_sensorDataMutex);
+				}
+
+				if (hts_valid)
+				{
+					memcpy(&hts_msg.data[0], &temperature, 4);
+					memcpy(&hts_msg.data[4], &humidity, 4);
+					(void)CanSend(&hts_msg);
+				}
+				last_hts_send = now;
+			}
+
+			tx_mutex_put(&g_canMutex);
+		}
 
 		tx_thread_sleep(20);
 	}

--- a/firmware/Core/Src/can_tx.c
+++ b/firmware/Core/Src/can_tx.c
@@ -49,7 +49,6 @@ void CraftSpeedMessage(t_can_message *msg, float speed)
 int CanSend(t_can_message* msg)
 {
 	FDCAN_TxHeaderTypeDef tx_header;
-	uint8_t attempt;
 	
 	const uint32_t dlc_map[] = {
 		FDCAN_DLC_BYTES_0,
@@ -72,14 +71,9 @@ int CanSend(t_can_message* msg)
 	tx_header.TxEventFifoControl = FDCAN_NO_TX_EVENTS;
 	tx_header.MessageMarker = 0;
 
-	for (attempt = 0; attempt < 3; ++attempt)
-	{
-		if (HAL_FDCAN_AddMessageToTxFifoQ(&hfdcan1, &tx_header, (uint8_t*)msg->data) == HAL_OK)
-			return 0;
-		tx_thread_sleep(1);
-	}
-	
-	return 1;
+	if (HAL_FDCAN_AddMessageToTxFifoQ(&hfdcan1, &tx_header, (uint8_t*)msg->data) != HAL_OK)
+		return 1;
+	return 0;
 }
 
 /**
@@ -91,140 +85,19 @@ int CanSend(t_can_message* msg)
 VOID CanTx(ULONG initial_input)
 {
 	t_can_message msg;
-	t_can_message batt_msg;
-	t_can_message ina_msg;
-	t_can_message ina_cur_msg;
-	t_can_message hts_msg;
-	uint32_t ina_dbg_count = 0u;
 	ULONG actual_flags;
-	ULONG last_ina_send = tx_time_get();
-	ULONG last_hts_send = tx_time_get();
-	const ULONG ina_send_ticks = 100; /* 1 second @ 100Hz tick */
-	const ULONG hts_send_ticks = 500; /* 5 seconds @ 100Hz tick */
 
 	while (1)
 	{
-		ULONG now = tx_time_get();
 		tx_event_flags_get(&g_eventFlags, FLAG_SENSOR_UPDATE, TX_OR_CLEAR, &actual_flags, TX_NO_WAIT);
 
-		float speed = 0.0f;
-		if (tx_mutex_get(&g_speedDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
-		{
-			speed = g_vehicleSpeed;
-			tx_mutex_put(&g_speedDataMutex);
-		}
-		else
-		{
-			tx_thread_sleep(1);
-			continue;
-		}
+		tx_mutex_get(&g_speedDataMutex, TX_WAIT_FOREVER);
+		float speed = g_vehicleSpeed;
+		tx_mutex_put(&g_speedDataMutex);
 
-		if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
-		{
-			CraftSpeedMessage(&msg, speed);
-
-			if ((now - last_ina_send) >= ina_send_ticks)
-			{
-				float stm_voltage = 0.0f;
-				uint8_t stm_percentage = 0xFFu;
-				uint8_t stm_valid = 0u;
-				float voltage = 0.0f;
-				float current = 0.0f;
-				uint8_t percentage = 0xFFu;
-				uint8_t ina_valid = 0u;
-
-				memset(&batt_msg, 0, sizeof(batt_msg));
-				batt_msg.id = CAN_ID_BATTERY_DATA;
-				batt_msg.len = 5;
-
-				memset(&ina_msg, 0, sizeof(ina_msg));
-				ina_msg.id = CAN_ID_INA231_DATA;
-				ina_msg.len = 5;
-
-				memset(&ina_cur_msg, 0, sizeof(ina_cur_msg));
-				ina_cur_msg.id = CAN_ID_INA231_CURRENT;
-				ina_cur_msg.len = 4;
-
-				if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
-				{
-					if (g_battery_data.data_valid)
-					{
-						stm_voltage = g_battery_data.voltage;
-						stm_percentage = g_battery_data.percentage;
-						stm_valid = 1u;
-					}
-					if (g_ina231_data.data_valid)
-					{
-						voltage = g_ina231_data.voltage;
-						current = g_ina231_data.current;
-						percentage = g_ina231_data.percentage;
-						ina_valid = 1u;
-					}
-					tx_mutex_put(&g_sensorDataMutex);
-				}
-
-				if (stm_valid)
-				{
-					batt_msg.data[0] = stm_percentage;
-					memcpy(&batt_msg.data[1], &stm_voltage, 4);
-					(void)CanSend(&batt_msg);
-				}
-
-				if (ina_valid)
-				{
-					uint32_t current_bits = 0u;
-					ina_msg.data[0] = percentage;
-					memcpy(&ina_msg.data[1], &voltage, 4);
-					memcpy(&ina_cur_msg.data[0], &current, 4);
-					memcpy(&current_bits, &current, sizeof(current_bits));
-					(void)CanSend(&ina_msg);
-					(void)CanSend(&ina_cur_msg);
-					ina_dbg_count++;
-					if ((ina_dbg_count % 10u) == 0u)
-					{
-						UartPrintf("[CAN 0x211] bits=0x%08lX bytes=%02X %02X %02X %02X\r\n",
-							(unsigned long)current_bits,
-							(unsigned int)ina_cur_msg.data[0],
-							(unsigned int)ina_cur_msg.data[1],
-							(unsigned int)ina_cur_msg.data[2],
-							(unsigned int)ina_cur_msg.data[3]);
-					}
-				}
-				last_ina_send = now;
-			}
-
-			if ((now - last_hts_send) >= hts_send_ticks)
-			{
-				float temperature = 0.0f;
-				float humidity = 0.0f;
-				uint8_t hts_valid = 0u;
-
-				memset(&hts_msg, 0, sizeof(hts_msg));
-				hts_msg.id = CAN_ID_HTS221_DATA;
-				hts_msg.len = 8;
-
-				if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
-				{
-					if (g_hts221_data.data_valid)
-					{
-						temperature = g_hts221_data.temperature;
-						humidity = g_hts221_data.humidity;
-						hts_valid = 1u;
-					}
-					tx_mutex_put(&g_sensorDataMutex);
-				}
-
-				if (hts_valid)
-				{
-					memcpy(&hts_msg.data[0], &temperature, 4);
-					memcpy(&hts_msg.data[4], &humidity, 4);
-					(void)CanSend(&hts_msg);
-				}
-				last_hts_send = now;
-			}
-
-			tx_mutex_put(&g_canMutex);
-		}
+		tx_mutex_get(&g_canMutex, TX_WAIT_FOREVER);
+		CraftSpeedMessage(&msg, speed);
+		tx_mutex_put(&g_canMutex);
 
 		tx_thread_sleep(20);
 	}

--- a/firmware/Core/Src/init_devices.c
+++ b/firmware/Core/Src/init_devices.c
@@ -17,7 +17,7 @@ void InitAllDevices(void)
 	HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);
 	PCA9685_InitAllDevices();
 
-	if (Battery_Init(&hi2c3) == HAL_OK)
+	if (BatteryInit(&hi2c3) == HAL_OK)
 	{
 		msg = "Battery: Initialized successfully\r\n";
 		HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);
@@ -28,7 +28,7 @@ void InitAllDevices(void)
 		HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);
 	}
 
-	if (HTS221_Init(&hi2c2) != HAL_OK)
+	if (HTS221Init(&hi2c2) != HAL_OK)
 	{
 		msg = "HTS221: Initialization failed!\r\n";
 		HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);

--- a/firmware/Core/Src/init_devices.c
+++ b/firmware/Core/Src/init_devices.c
@@ -28,7 +28,7 @@ void InitAllDevices(void)
 		HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);
 	}
 
-	if (HTS221Init(&hi2c2) != HAL_OK)
+	if (Hts221Init(&hi2c2) != HAL_OK)
 	{
 		msg = "HTS221: Initialization failed!\r\n";
 		HAL_UART_Transmit(&huart1, (uint8_t*)msg, strlen(msg), HAL_MAX_DELAY);

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -765,12 +765,3 @@ void SensorBatteryThread(ULONG initial_input)
     }
 }
 
-/**
- * @brief Thread entry for sleeping INA231
- * @param initial_input Thread argument
- */
-void SensorINA231Thread(ULONG initial_input)
-{
-    (void)initial_input;
-    while (1) { tx_thread_sleep(TX_WAIT_FOREVER); }
-}

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -188,7 +188,7 @@ static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
  * @param  hi2c I2C handle
  * @return HAL_StatusTypeDef 
  */
-HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
+HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
 {
     if (hi2c == NULL || hi2c->Instance == NULL)
     {
@@ -310,7 +310,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
  * @param  hi2c I2C handle
  * @return HAL_StatusTypeDef 
  */
-HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
+HAL_StatusTypeDef BatteryInit(I2C_HandleTypeDef *hi2c)
 {
     UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
                g_ina231Addr7bit, (hi2c == &hi2c2) ? 2 : 1);
@@ -488,14 +488,14 @@ void SensorHTS221Thread(ULONG initial_input)
     UartPrint("HTS221 Thread: Started\r\n");
     tx_thread_sleep(100);
 
-    while (!g_battery_power_ready)
+    while (!g_batteryPowerReady)
     {
         tx_thread_sleep(50);
     }
 
     while (!hts_ready)
     {
-        init_status = HTS221_Init(&hi2c2);
+        init_status = Hts221Init(&hi2c2);
         if (init_status == HAL_OK)
         {
             hts_ready = true;
@@ -586,7 +586,7 @@ void SensorHTS221Thread(ULONG initial_input)
 
             while (!hts_ready)
             {
-                init_status = HTS221_Init(&hi2c2);
+                init_status = Hts221Init(&hi2c2);
                 if (init_status == HAL_OK)
                 {
                     hts_ready = true;
@@ -658,7 +658,7 @@ void SensorBatteryThread(ULONG initial_input)
     tx_thread_sleep(200);
 
     /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
-    if (Battery_Init(&hi2c2) != HAL_OK) 
+    if (BatteryInit(&hi2c2) != HAL_OK) 
     {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_batteryPowerReady = true;

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -9,50 +9,6 @@
 #include "sensors.h"
 
 /* ============================================================================
- * External Fallbacks
- * ============================================================================ */
-/* Fallback for external functions if not in headers */
-extern void UartPrint(const char* msg);
-extern void UartPrintf(const char* format, ...);
-extern void SoftwareDelay(uint32_t ms);
-
-/* ============================================================================
- * Private Constants
- * ============================================================================ */
-static const ULONG SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
-static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
-
-/* ============================================================================
- * Global Variables
- * ============================================================================ */
-TX_MUTEX                    g_sensorDataMutex;
-TX_MUTEX                    g_i2cMutex; /* Hardware lock for the I2C2 Bus */
-
-HTS221_Data_t               g_hts221_data;
-Battery_Data_t              g_battery_data;
-INA231_Data_t               g_ina231_data;
-
-/* ============================================================================
- * Private Variables
- * ============================================================================ */
-static volatile bool        g_battery_power_ready = false;
-static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
-static HTS221_Calibration_t calib_data;
-
-/* ============================================================================
- * Private Function Prototypes
- * ============================================================================ */
-static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len);
-static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len);
-
-static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
-static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
-
-static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
-static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
-
-
-/* ============================================================================
  * Initialization
  * ============================================================================ */
 
@@ -82,11 +38,7 @@ void SensorsInit(void)
  * @param  len Length
  * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
-                                          uint16_t dev_addr,
-                                          uint16_t mem_addr,
-                                          uint8_t *buf,
-                                          uint16_t len)
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
@@ -103,13 +55,7 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
             return HAL_BUSY;
     }
 
-    status = HAL_I2C_Mem_Read(hi2c,
-                              dev_addr,
-                              mem_addr,
-                              I2C_MEMADD_SIZE_8BIT,
-                              buf,
-                              len,
-                              SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Read(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, buf, len, SENSOR_I2C_TIMEOUT_MS);
 
     if (status != HAL_OK)
     {
@@ -121,7 +67,10 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
         }
     }
 
-    if (thread) tx_mutex_put(&g_i2cMutex);
+    if (thread)
+    {
+        tx_mutex_put(&g_i2cMutex);
+    }
     return status;
 }
 
@@ -134,11 +83,7 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
  * @param  len Length
  * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
-                                           uint16_t dev_addr,
-                                           uint16_t mem_addr,
-                                           const uint8_t *buf,
-                                           uint16_t len)
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
@@ -151,18 +96,17 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
     if (thread)
     {
         if (tx_mutex_get(&g_i2cMutex, SENSOR_I2C_MUTEX_TIMEOUT_TICKS) != TX_SUCCESS)
+        {
             return HAL_BUSY;
+        }
     }
 
-    status = HAL_I2C_Mem_Write(hi2c,
-                               dev_addr,
-                               mem_addr,
-                               I2C_MEMADD_SIZE_8BIT,
-                               (uint8_t *)buf,
-                               len,
-                               SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Write(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, (uint8_t *)buf, len, SENSOR_I2C_TIMEOUT_MS);
 
-    if (thread) tx_mutex_put(&g_i2cMutex);
+    if (thread)
+    {
+        tx_mutex_put(&g_i2cMutex);
+    }
     return status;
 }
 
@@ -196,7 +140,8 @@ static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
 
-    if (status != HAL_OK) return HAL_ERROR;
+    if (status != HAL_OK) 
+        return HAL_ERROR;
 
     calib_data.H0_rh = buffer[0] >> 1;
     calib_data.H1_rh = buffer[1] >> 1;
@@ -257,9 +202,18 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
     uint8_t h_low, t_low, t_high;
     int16_t h_raw, t_raw;
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
-    if (SensorI2cMemRead(hi2c, addr, HTS221_HUMIDITY_OUT_L, &h_low, 1) != HAL_OK) return HAL_ERROR;
-    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_L, &t_low, 1) != HAL_OK) return HAL_ERROR;
-    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_H, &t_high, 1) != HAL_OK) return HAL_ERROR;
+    if (SensorI2cMemRead(hi2c, addr, HTS221_HUMIDITY_OUT_L, &h_low, 1) != HAL_OK)
+    {
+        return HAL_ERROR;
+    }
+    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_L, &t_low, 1) != HAL_OK)
+    {
+        return HAL_ERROR;
+    }
+    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_H, &t_high, 1) != HAL_OK)
+    {
+        return HAL_ERROR;
+    }
 
     h_raw = (int8_t)h_low;
     t_raw = (int16_t)(t_low | (t_high << 8));
@@ -293,20 +247,30 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
     const float soc_min_v = 6.00f;
     float pct = 0.0f;
 
-    if (voltage_v >= soc_max_v) {
+    if (voltage_v >= soc_max_v)
+    {
         return 100u;
     }
-    if (voltage_v <= soc_min_v) {
+    if (voltage_v <= soc_min_v)
+    {
         return 0u;
     }
-    if (voltage_v >= soc_nom_v) {
+    if (voltage_v >= soc_nom_v)
+    {
         pct = 50.0f + ((voltage_v - soc_nom_v) / (soc_max_v - soc_nom_v)) * 50.0f;
-    } else {
+    }
+    else
+    {
         pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
     }
-
-    if (pct < 0.0f) pct = 0.0f;
-    if (pct > 100.0f) pct = 100.0f;
+    if (pct < 0.0f) 
+    {
+        pct = 0.0f;
+    }
+    if (pct > 100.0f)
+    {
+        pct = 100.0f;
+    }
     return (uint8_t)(pct + 0.5f);
 }
 
@@ -354,9 +318,7 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
         read_fail_count++;
         if ((read_fail_count % 25u) == 0u)
         {
-            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n",
-                       (unsigned int)g_ina231_addr_7bit,
-                       (unsigned long)HAL_I2C_GetError(hi2c));
+            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n", (unsigned int)g_ina231_addr_7bit, (unsigned long)HAL_I2C_GetError(hi2c));
         }
     }
 
@@ -367,11 +329,8 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
         return HAL_ERROR;
     }
 
-    {
-        uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-        *voltage = bus_raw * 1.25e-3f;
-    }
-
+    uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+    *voltage = bus_raw * 1.25e-3f;
     *percentage = BatteryPercentFrom2SVoltage(*voltage);
     return HAL_OK;
 }
@@ -389,7 +348,10 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
     HAL_StatusTypeDef status;
     const uint16_t dev_addr = (uint16_t)(0x41u << 1);
 
-    if (voltage == NULL || percentage == NULL) return HAL_ERROR;
+    if (voltage == NULL || percentage == NULL) 
+    {
+        return HAL_ERROR;
+    }
 
     status = SensorI2cMemRead(hi2c, dev_addr, INA219_REG_BUS_V, buf, 2);
 
@@ -400,13 +362,9 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
         return HAL_ERROR;
     }
 
-    /* INA219-style bus voltage register decoding used by expansion monitor. */
-    {
-        uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-        uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
-        *voltage = voltage_bits * 0.004f;
-    }
-
+    uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+    uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
+    *voltage = voltage_bits * 0.004f;
     *percentage = BatteryPercentFrom2SVoltage(*voltage);
 
     return HAL_OK;
@@ -429,7 +387,10 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
     const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
 
-    if (current == NULL) return HAL_ERROR;
+    if (current == NULL) 
+    {
+        return HAL_ERROR;
+    }
 
     /* Read current register (0x04) for diagnostics/comparison only */
     status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_CURRENT, buf, 2);
@@ -447,9 +408,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
         dbg_fail_count++;
         if ((dbg_fail_count % 25u) == 0u)
         {
-            UartPrintf("[INA231 CUR] shunt read fail count=%lu err=0x%08lX\r\n",
-                       (unsigned long)dbg_fail_count,
-                       (unsigned long)HAL_I2C_GetError(hi2c));
+            UartPrintf("[INA231 CUR] shunt read fail count=%lu err=0x%08lX\r\n", (unsigned long)dbg_fail_count, (unsigned long)HAL_I2C_GetError(hi2c));
         }
         return HAL_ERROR;
     }
@@ -460,13 +419,8 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     dbg_sample_count++;
     if ((dbg_sample_count % 10u) == 0u)
     {
-        UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n",
-                   (int)current_raw,
-                   (unsigned int)buf[0],
-                   (unsigned int)buf[1],
-                   (int)shunt_raw,
-                   (unsigned int)shunt_buf[0],
-                   (unsigned int)shunt_buf[1]);
+        UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n", (int)current_raw,
+                   (unsigned int)buf[0], (unsigned int)buf[1], (int)shunt_raw, (unsigned int)shunt_buf[0], (unsigned int)shunt_buf[1]);
     }
 
     return HAL_OK;
@@ -550,8 +504,7 @@ void SensorHTS221Thread(ULONG initial_input)
             int16_t temp_int = (int16_t)temp;
             int16_t hum_int = (int16_t)hum;
 
-            if (temp_int != last_temp_int || hum_int != last_hum_int ||
-                (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
             {
                 /* Expected application integration using CanSend */
                 last_temp_int = temp_int;
@@ -660,9 +613,13 @@ void SensorBatteryThread(ULONG initial_input)
     UartPrint("Battery Thread: Started\r\n");
     last_send_time = tx_time_get();
     if (last_send_time >= SEND_INTERVAL_TICKS)
+    {
         last_send_time -= SEND_INTERVAL_TICKS;
+    }
     else
+    {
         last_send_time = 0;
+    }
     last_ina_ok_time = last_send_time;
     last_current_sample_time = last_send_time;
 
@@ -670,10 +627,13 @@ void SensorBatteryThread(ULONG initial_input)
     tx_thread_sleep(200);
 
     /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
-    if (Battery_Init(&hi2c2) != HAL_OK) {
+    if (Battery_Init(&hi2c2) != HAL_OK) 
+    {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_battery_power_ready = true;
-    } else {
+    } 
+    else 
+    {
         UartPrint("Battery Thread: INA231 initialized successfully\r\n");
         g_battery_power_ready = true;
     }
@@ -695,7 +655,6 @@ void SensorBatteryThread(ULONG initial_input)
 
         (void)last_send_time;
 
-        /* Live-only mode: attempt INA read; data_valid drives CAN publication. */
         expansion_voltage = 0.0f;
         expansion_percentage = 0u;
         expansion_status = ExpansionBattery_Read(&hi2c3, &expansion_voltage, &expansion_percentage);
@@ -720,7 +679,6 @@ void SensorBatteryThread(ULONG initial_input)
 
             if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
             {
-                /* g_ina231_data usage is intact despite type missing externally */
                 g_ina231_data.voltage = last_ina_voltage;
                 g_ina231_data.current = last_current_amps;
                 g_ina231_data.power = 0.0f;

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -1,68 +1,66 @@
 /**
  ******************************************************************************
-* @file           : sensors.c
-* @brief          : Sensor threads management and drivers
-* @details        : Exact port of bare-metal INA231 logic to ThreadX
-******************************************************************************
-*/
+ * @file            : sensors.c
+ * @brief           : Sensor threads management and drivers
+ * @details         : ThreadX-compatible port of bare-metal INA231 and HTS221 logic
+ ******************************************************************************
+ */
 
 #include "sensors.h"
-#include <string.h>
-#include <math.h>
 
-/* Fallback for external functions if not in headers */
+/* External References (Fallbacks) -------------------------------------------*/
 extern void UartPrint(const char* msg);
 extern void UartPrintf(const char* format, ...);
 extern void SoftwareDelay(uint32_t ms);
 
-TX_MUTEX                    g_sensorDataMutex;
-TX_MUTEX                    g_i2cMutex; /* Hardware lock for the I2C2 Bus */
-static volatile bool        g_battery_power_ready = false;
-static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+/* Private Constants ---------------------------------------------------------*/
+static const ULONG    SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
+static const uint32_t SENSOR_I2C_TIMEOUT_MS          = 100;
 
-HTS221_Data_t               g_hts221_data;
-Battery_Data_t              g_battery_data;
-INA231_Data_t               g_ina231_data;
+/* Global Variables ----------------------------------------------------------*/
+TX_MUTEX              g_sensorDataMutex;
+TX_MUTEX              g_i2cMutex; /* Hardware lock for the I2C2 Bus */
 
-static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
-                                          uint16_t dev_addr,
-                                          uint16_t mem_addr,
-                                          uint8_t *buf,
-                                          uint16_t len);
+HTS221_Data_t         g_hts221_data;
+Battery_Data_t        g_battery_data;
+INA231_Data_t         g_ina231_data;
 
-static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
-{
-    /* SOC calibration for the deployed 2S2P pack under load. */
-    const float soc_max_v = 8.15f;
-    const float soc_nom_v = 7.40f;
-    const float soc_min_v = 6.00f;
-    float pct = 0.0f;
-
-    if (voltage_v >= soc_max_v) {
-        return 100u;
-    }
-    if (voltage_v <= soc_min_v) {
-        return 0u;
-    }
-    if (voltage_v >= soc_nom_v) {
-        pct = 50.0f + ((voltage_v - soc_nom_v) / (soc_max_v - soc_nom_v)) * 50.0f;
-    } else {
-        pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
-    }
-
-    if (pct < 0.0f) pct = 0.0f;
-    if (pct > 100.0f) pct = 100.0f;
-    return (uint8_t)(pct + 0.5f);
-}
+/* Private Variables ---------------------------------------------------------*/
+static volatile bool  g_battery_power_ready = false;
+static uint8_t        g_ina231_addr_7bit    = 0; /* Expected to be set during init */
 static HTS221_Calibration_t calib_data;
 
-static const ULONG SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
-static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
+/* Private Function Prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit);
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len);
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len);
 
+static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
+static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+
+static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value);
+static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value);
+static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit);
+
+static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
+static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
+
+
+/* ============================================================================
+ * I2C Abstraction Layer (Thread-Safe)
+ * ============================================================================ */
+
+/**
+ * @brief  Probes an I2C address in a thread-safe manner.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  dev_addr_7bit 7-bit I2C device address.
+ * @return HAL_StatusTypeDef
+ */
 static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
+
     if (hi2c == NULL || hi2c->Instance == NULL)
     {
         UartPrint("[I2C GUARD] probe null handle\r\n");
@@ -83,15 +81,21 @@ static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t 
     return status;
 }
 
-static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
-                                          uint16_t dev_addr,
-                                          uint16_t mem_addr,
-                                          uint8_t *buf,
-                                          uint16_t len)
+/**
+ * @brief  Reads from I2C memory securely using Mutex locks.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  dev_addr 8-bit shifted I2C device address.
+ * @param  mem_addr Internal memory address to read.
+ * @param  buf Data buffer for read operation.
+ * @param  len Amount of data to be read.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
     uint8_t reg_addr = (uint8_t)(mem_addr & 0xFFu);
+
     if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
     {
         UartPrint("[I2C GUARD] mem read invalid args\r\n");
@@ -104,13 +108,7 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
             return HAL_BUSY;
     }
 
-    status = HAL_I2C_Mem_Read(hi2c,
-                              dev_addr,
-                              mem_addr,
-                              I2C_MEMADD_SIZE_8BIT,
-                              buf,
-                              len,
-                              SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Read(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, buf, len, SENSOR_I2C_TIMEOUT_MS);
 
     if (status != HAL_OK)
     {
@@ -123,17 +121,24 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
     }
 
     if (thread) tx_mutex_put(&g_i2cMutex);
+    
     return status;
 }
 
-static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
-                                           uint16_t dev_addr,
-                                           uint16_t mem_addr,
-                                           const uint8_t *buf,
-                                           uint16_t len)
+/**
+ * @brief  Writes to I2C memory securely using Mutex locks.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  dev_addr 8-bit shifted I2C device address.
+ * @param  mem_addr Internal memory address to write.
+ * @param  buf Data buffer for write operation.
+ * @param  len Amount of data to be written.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
+
     if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
     {
         UartPrint("[I2C GUARD] mem write invalid args\r\n");
@@ -146,15 +151,10 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
             return HAL_BUSY;
     }
 
-    status = HAL_I2C_Mem_Write(hi2c,
-                               dev_addr,
-                               mem_addr,
-                               I2C_MEMADD_SIZE_8BIT,
-                               (uint8_t *)buf,
-                               len,
-                               SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Write(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, (uint8_t *)buf, len, SENSOR_I2C_TIMEOUT_MS);
 
     if (thread) tx_mutex_put(&g_i2cMutex);
+    
     return status;
 }
 
@@ -162,36 +162,57 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
  * HTS221 Driver Implementation (Thread-Safe)
  * ============================================================================ */
 
+/**
+ * @brief  Writes a single byte to an HTS221 register.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  reg Target register address.
+ * @param  data Byte to write.
+ * @return HAL_StatusTypeDef
+ */
 static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
 {
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     return SensorI2cMemWrite(hi2c, addr, reg, &data, 1);
 }
 
+/**
+ * @brief  Reads factory calibration values from HTS221 memory.
+ * @param  hi2c Pointer to the I2C handle.
+ * @return HAL_StatusTypeDef
+ */
 static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
 {
     uint8_t t0_msb, t1_msb;
     uint8_t buffer[16];
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
+    
     HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
-
     if (status != HAL_OK) return HAL_ERROR;
 
     calib_data.H0_rh = buffer[0] >> 1;
     calib_data.H1_rh = buffer[1] >> 1;
     calib_data.T0_degC = buffer[2];
     calib_data.T1_degC = buffer[3];
+    
     t0_msb = (buffer[5] & 0x03);
     t1_msb = (buffer[5] & 0x0C) >> 2;
+    
     calib_data.T0_degC = ((t0_msb << 8) | calib_data.T0_degC) >> 3;
     calib_data.T1_degC = ((t1_msb << 8) | calib_data.T1_degC) >> 3;
+    
     calib_data.H0_T0_out = (int16_t)(buffer[6] | (buffer[7] << 8));
     calib_data.H1_T0_out = (int16_t)(buffer[8] | (buffer[9] << 8));
     calib_data.T0_out = (int16_t)(buffer[12] | (buffer[13] << 8));
     calib_data.T1_out = (int16_t)(buffer[14] | (buffer[15] << 8));
+    
     return HAL_OK;
 }
 
+/**
+ * @brief  Initialize the HTS221 sensor.
+ * @param  hi2c Pointer to the I2C handle.
+ * @return HAL_StatusTypeDef HAL status.
+ */
 HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
 {
     if (hi2c == NULL || hi2c->Instance == NULL)
@@ -199,21 +220,31 @@ HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
         UartPrint("HTS221: init null I2C handle\r\n");
         return HAL_ERROR;
     }
+    
     if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
     {
         UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
         return HAL_ERROR;
     }
+    
     if (HTS221_ReadCalibration(hi2c) != HAL_OK)
     {
         UartPrint("HTS221: Failed to read calibration\r\n");
         return HAL_ERROR;
     }
+    
     UartPrint("HTS221: Initialized successfully\r\n");
     SoftwareDelay(500);
     return HAL_OK;
 }
 
+/**
+ * @brief  Read both temperature and humidity from HTS221.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  temperature Pointer to store the temperature in Celsius.
+ * @param  humidity Pointer to store the humidity in percentage.
+ * @return HAL_StatusTypeDef HAL status.
+ */
 HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity)
 {
     if (hi2c == NULL || hi2c->Instance == NULL || temperature == NULL || humidity == NULL)
@@ -221,9 +252,11 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
         UartPrint("HTS221: read invalid args\r\n");
         return HAL_ERROR;
     }
+    
     uint8_t h_low, t_low, t_high;
     int16_t h_raw, t_raw;
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
+    
     if (SensorI2cMemRead(hi2c, addr, HTS221_HUMIDITY_OUT_L, &h_low, 1) != HAL_OK) return HAL_ERROR;
     if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_L, &t_low, 1) != HAL_OK) return HAL_ERROR;
     if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_H, &t_high, 1) != HAL_OK) return HAL_ERROR;
@@ -232,33 +265,339 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
     t_raw = (int16_t)(t_low | (t_high << 8));
 
     float t_temp = (float)(t_raw - calib_data.T0_out) * (float)(calib_data.T1_degC - calib_data.T0_degC) /
-                (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
+                   (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
+                   
     float h_temp = ((float)(h_raw - calib_data.H0_T0_out)) * ((float)(calib_data.H1_rh - calib_data.H0_rh)) /
-                ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
+                   ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
+                   
     if (h_temp < 0.0f) h_temp = 0.0f;
     if (h_temp > 100.0f) h_temp = 100.0f;
+    
     *temperature = t_temp;
     *humidity = h_temp;
+    
     return HAL_OK;
 }
 
+/* ============================================================================
+ * INA231 / Battery Driver Implementation
+ * ============================================================================ */
+
+/**
+ * @brief  Computes approximate battery percentage based on a 2S pack load curve.
+ * @param  voltage_v Given voltage in volts.
+ * @return uint8_t Percentage from 0 to 100.
+ */
+static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
+{
+    /* SOC calibration for the deployed 2S2P pack under load. */
+    const float soc_max_v = 8.15f;
+    const float soc_nom_v = 7.40f;
+    const float soc_min_v = 6.00f;
+    float pct = 0.0f;
+
+    if (voltage_v >= soc_max_v) return 100u;
+    if (voltage_v <= soc_min_v) return 0u;
+
+    if (voltage_v >= soc_nom_v) {
+        pct = 50.0f + ((voltage_v - soc_nom_v) / (soc_max_v - soc_nom_v)) * 50.0f;
+    } else {
+        pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
+    }
+
+    if (pct < 0.0f) pct = 0.0f;
+    if (pct > 100.0f) pct = 100.0f;
+    
+    return (uint8_t)(pct + 0.5f);
+}
+
+/**
+ * @brief  Writes 16-bit payload to an INA231 register.
+ * @param  hi2c Pointer to I2C handle.
+ * @param  reg Target register address.
+ * @param  value 16-bit value to write.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value)
+{
+    uint8_t data[2];
+    HAL_StatusTypeDef status;
+
+    data[0] = (uint8_t)((value >> 8) & 0xFF);   /* MSB */
+    data[1] = (uint8_t)(value & 0xFF);          /* LSB */
+
+    status = SensorI2cMemWrite(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), reg, data, 2);
+
+    if (status != HAL_OK)
+    {
+        uint32_t hal_err = HAL_I2C_GetError(hi2c);
+        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n", reg, status, (unsigned long)hal_err);
+    }
+
+    return status;
+}
+
+/**
+ * @brief  Reads 16-bit payload from an INA231 register.
+ * @param  hi2c Pointer to I2C handle.
+ * @param  dev_addr_7bit Target device 7-bit address.
+ * @param  reg Target register address.
+ * @param  value Pointer to store read 16-bit value.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+
+    if (value == NULL) return HAL_ERROR;
+
+    status = SensorI2cMemRead(hi2c, (uint16_t)(dev_addr_7bit << 1), reg, buf, 2);
+    if (status != HAL_OK) return status;
+
+    *value = (uint16_t)((buf[0] << 8) | buf[1]);
+    return HAL_OK;
+}
+
+/**
+ * @brief  Applies standard configuration to INA231 and validates.
+ * @param  hi2c Pointer to I2C handle.
+ * @param  dev_addr_7bit Target device 7-bit address.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
+{
+    /* Assume these constants exist in your actual application layer */
+    #ifndef INA231_CONFIG_VAL
+    #define INA231_CONFIG_VAL 0x4127
+    #endif
+    #ifndef INA231_CALIB_VAL
+    #define INA231_CALIB_VAL  0x0A00
+    #endif
+
+    uint8_t prev_addr = g_ina231_addr_7bit;
+    uint16_t readback = 0u;
+    HAL_StatusTypeDef status;
+
+    g_ina231_addr_7bit = dev_addr_7bit;
+
+    status = INA231_WriteRegister(hi2c, INA219_REG_CONFIG, INA231_CONFIG_VAL);
+    if (status != HAL_OK) { g_ina231_addr_7bit = prev_addr; return status; }
+
+    status = INA231_WriteRegister(hi2c, INA219_REG_CALIBRATION, INA231_CALIB_VAL);
+    if (status != HAL_OK) { g_ina231_addr_7bit = prev_addr; return status; }
+
+    status = INA231_ReadRegister(hi2c, dev_addr_7bit, INA219_REG_CONFIG, &readback);
+    if (status != HAL_OK || readback != INA231_CONFIG_VAL)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+/**
+ * @brief  Initialize the Battery Monitor (INA231).
+ * @param  hi2c Pointer to the I2C handle.
+ * @return HAL_StatusTypeDef HAL status.
+ */
+HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
+{
+    /* External assumed constant for INA231 default */
+    #ifndef INA231_I2C_ADDRESS
+    #define INA231_I2C_ADDRESS 0x40
+    #endif
+
+    UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
+               INA231_I2C_ADDRESS, (hi2c == &hi2c2) ? 2 : (hi2c == &hi2c3) ? 3 : 1);
+
+    /* PE13 power is enabled during GPIO init in main.c. */
+    tx_thread_sleep(2);
+    UartPrint("Battery: PE13 power assumed enabled\r\n");
+    
+    (void)hi2c;
+    g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+    UartPrint("Battery: Startup safe mode - probe deferred to runtime reads\r\n");
+    return HAL_OK;
+}
+
+/**
+ * @brief  Read the bus voltage and estimated percentage from the battery monitor.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  voltage Pointer to store the voltage in Volts.
+ * @param  percentage Pointer to store the calculated battery percentage (0-100).
+ * @return HAL_StatusTypeDef HAL status.
+ */
+HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+    static uint32_t read_fail_count = 0u;
+
+    if (hi2c == NULL || hi2c->Instance == NULL || voltage == NULL || percentage == NULL)
+    {
+        UartPrint("Battery: read invalid args\r\n");
+        return HAL_ERROR;
+    }
+
+    /* Read bus voltage register */
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_BUS_V, buf, 2);
+    if (status != HAL_OK)
+    {
+        read_fail_count++;
+        if ((read_fail_count % 25u) == 0u)
+        {
+            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n",
+                       (unsigned int)g_ina231_addr_7bit,
+                       (unsigned long)HAL_I2C_GetError(hi2c));
+        }
+        
+        *voltage = 0.0f;
+        *percentage = 0;
+        return HAL_ERROR;
+    }
+
+    uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+    *voltage = bus_raw * 1.25e-3f;
+    *percentage = BatteryPercentFrom2SVoltage(*voltage);
+    
+    return HAL_OK;
+}
+
+/**
+ * @brief  Reads voltage and percentage from the Expansion Battery monitor.
+ * @param  hi2c Pointer to I2C handle.
+ * @param  voltage Output voltage storage.
+ * @param  percentage Output percentage storage.
+ * @return HAL_StatusTypeDef
+ */
+static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+    const uint16_t dev_addr = (uint16_t)(0x41u << 1);
+
+    if (voltage == NULL || percentage == NULL) return HAL_ERROR;
+
+    status = SensorI2cMemRead(hi2c, dev_addr, INA219_REG_BUS_V, buf, 2);
+
+    if (status != HAL_OK)
+    {
+        *voltage = 0.0f;
+        *percentage = 0;
+        return HAL_ERROR;
+    }
+
+    /* INA219-style bus voltage register decoding used by expansion monitor. */
+    uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+    uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
+    *voltage = voltage_bits * 0.004f;
+    *percentage = BatteryPercentFrom2SVoltage(*voltage);
+
+    return HAL_OK;
+}
+
+/**
+ * @brief  Read current from INA226/INA231 shunt resistor.
+ * @param  hi2c Pointer to the I2C handle.
+ * @param  current Pointer to store current in Amps.
+ * @return HAL_StatusTypeDef HAL status.
+ */
+HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
+{
+    uint8_t buf[2];
+    uint8_t shunt_buf[2];
+    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef shunt_status;
+    
+    static uint32_t dbg_sample_count = 0u;
+    static uint32_t dbg_fail_count = 0u;
+    
+    const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
+    const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
+
+    if (current == NULL) return HAL_ERROR;
+
+    /* Read current register for diagnostics/comparison only */
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_CURRENT, buf, 2);
+    if (status != HAL_OK)
+    {
+        buf[0] = 0u;
+        buf[1] = 0u;
+    }
+
+    /* Read shunt register and compute current directly: I = Vshunt / Rshunt */
+    shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_SHUNT_V, shunt_buf, 2);
+    if (shunt_status != HAL_OK)
+    {
+        *current = 0.0f;
+        dbg_fail_count++;
+        if ((dbg_fail_count % 25u) == 0u)
+        {
+            UartPrintf("[INA231 CUR] shunt read fail count=%lu err=0x%08lX\r\n",
+                       (unsigned long)dbg_fail_count,
+                       (unsigned long)HAL_I2C_GetError(hi2c));
+        }
+        return HAL_ERROR;
+    }
+    
+    int16_t current_raw = (int16_t)((buf[0] << 8) | buf[1]);
+    int16_t shunt_raw = (int16_t)((shunt_buf[0] << 8) | shunt_buf[1]);
+    
+    *current = (shunt_raw * shunt_lsb_v) / shunt_res_ohm;
+
+    dbg_sample_count++;
+    if ((dbg_sample_count % 10u) == 0u)
+    {
+        UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n",
+                   (int)current_raw, (unsigned int)buf[0], (unsigned int)buf[1],
+                   (int)shunt_raw, (unsigned int)shunt_buf[0], (unsigned int)shunt_buf[1]);
+    }
+
+    return HAL_OK;
+}
+
+/* ============================================================================
+ * Thread Definitions
+ * ============================================================================ */
+
+/**
+ * @brief  ThreadX entry function for HTS221 Sensor polling.
+ * @param  initial_input ThreadX parameter (unused).
+ */
 void SensorHTS221Thread(ULONG initial_input)
 {
+    /* Assume external dependencies */
+    #ifndef MUTEX_WAIT_TICKS
+    #define MUTEX_WAIT_TICKS 100
+    #endif
+    #ifndef CAN_ID_HTS221_DATA
+    #define CAN_ID_HTS221_DATA 0x101
+    #endif
+
+    /* Assumed external definitions needed for compilation logic representation */
+    typedef struct { uint32_t id; uint8_t len; uint8_t data[8]; } t_can_message;
+    extern TX_MUTEX g_canMutex;
+    extern void CanSend(t_can_message *msg);
+
     float temp, hum;
     float last_temp = 0.0f, last_hum = 0.0f;
-    HAL_StatusTypeDef   status;
-    HAL_StatusTypeDef   init_status;
-    static int16_t      last_temp_int = -99;
-    static int16_t      last_hum_int = -99;
-    static ULONG        last_send_time = 0;
-    static const ULONG  HEARTBEAT_INTERVAL = 500; /* 5 seconds @ 100Hz tick */
-    static const ULONG  HTS_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    HAL_StatusTypeDef status, init_status;
+    
+    static int16_t last_temp_int = -99;
+    static int16_t last_hum_int = -99;
+    static ULONG last_send_time = 0;
+    
+    static const ULONG HEARTBEAT_INTERVAL = 500;        /* 5 seconds @ 100Hz tick */
+    static const ULONG HTS_STALE_TIMEOUT_TICKS = 1000;  /* 10 seconds without valid read => stale */
     static const uint8_t HTS_REINIT_THRESHOLD = 5;
-    uint32_t            init_attempts = 0;
-    uint8_t             consecutive_failures = 0;
-    bool                hts_ready = false;
-    bool                have_sample = false;
-    ULONG               last_hts_ok_time = 0;
+    
+    uint32_t init_attempts = 0;
+    uint8_t consecutive_failures = 0;
+    bool hts_ready = false;
+    bool have_sample = false;
+    ULONG last_hts_ok_time = 0;
 
     (void)initial_input;
     UartPrint("HTS221 Thread: Started\r\n");
@@ -300,6 +639,7 @@ void SensorHTS221Thread(ULONG initial_input)
             last_hum = hum;
             have_sample = true;
             last_hts_ok_time = current_time;
+            
             if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
             {
                 g_hts221_data.temperature = last_temp;
@@ -308,11 +648,11 @@ void SensorHTS221Thread(ULONG initial_input)
                 g_hts221_data.data_valid = 1;
                 tx_mutex_put(&g_sensorDataMutex);
             }
+            
             int16_t temp_int = (int16_t)temp;
             int16_t hum_int = (int16_t)hum;
 
-            if (temp_int != last_temp_int || hum_int != last_hum_int ||
-                (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
             {
                 t_can_message msg;
                 memset(&msg, 0, sizeof(msg));
@@ -320,11 +660,13 @@ void SensorHTS221Thread(ULONG initial_input)
                 msg.len = 8;
                 memcpy(&msg.data[0], &last_temp, 4);
                 memcpy(&msg.data[4], &last_hum, 4);
+                
                 if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
                 {
                     CanSend(&msg);
                     tx_mutex_put(&g_canMutex);
                 }
+                
                 last_temp_int = temp_int;
                 last_hum_int = hum_int;
                 last_send_time = current_time;
@@ -357,6 +699,7 @@ void SensorHTS221Thread(ULONG initial_input)
                 msg.len = 8;
                 memcpy(&msg.data[0], &last_temp, 4);
                 memcpy(&msg.data[4], &last_hum, 4);
+                
                 if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
                 {
                     CanSend(&msg);
@@ -405,280 +748,57 @@ void SensorHTS221Thread(ULONG initial_input)
 }
 
 /**
- * @brief Initialize sensor data structures and mutexes.
+ * @brief  ThreadX entry function for Battery Sensor polling.
+ * @param  initial_input ThreadX parameter (unused).
  */
-void SensorsInit(void)
-{
-    tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
-    tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
-    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
-    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
-    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
-}
-
-/* ============================================================================
-* Exact Port of bare-metal INA231 logic to RTOS
-* ============================================================================ */
-
-static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value)
-{
-    uint8_t data[2];
-    HAL_StatusTypeDef status;
-
-    data[0] = (uint8_t)((value >> 8) & 0xFF);   // MSB
-    data[1] = (uint8_t)(value & 0xFF);          // LSB
-
-    /* Use detected INA231 address shifted to 8-bit */
-    status = SensorI2cMemWrite(hi2c,
-                               (uint16_t)(g_ina231_addr_7bit << 1),
-                               reg,
-                               data,
-                               2);
-
-    if (status != HAL_OK)
-    {
-        uint32_t hal_err = HAL_I2C_GetError(hi2c);
-        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n",
-                   reg,
-                   status,
-                   (unsigned long)hal_err);
-    }
-
-    return status;
-}
-
-static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value)
-{
-    uint8_t buf[2];
-    HAL_StatusTypeDef status;
-
-    if (value == NULL)
-        return HAL_ERROR;
-
-    status = SensorI2cMemRead(hi2c, (uint16_t)(dev_addr_7bit << 1), reg, buf, 2);
-    if (status != HAL_OK)
-        return status;
-
-    *value = (uint16_t)((buf[0] << 8) | buf[1]);
-    return HAL_OK;
-}
-
-static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
-{
-    uint8_t prev_addr = g_ina231_addr_7bit;
-    uint16_t readback = 0u;
-    HAL_StatusTypeDef status;
-
-    g_ina231_addr_7bit = dev_addr_7bit;
-
-    status = INA231_WriteRegister(hi2c, INA231_REG_CONFIG, INA231_CONFIG_VAL);
-    if (status != HAL_OK)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return status;
-    }
-
-    status = INA231_WriteRegister(hi2c, INA231_REG_CALIBRATION, INA231_CALIB_VAL);
-    if (status != HAL_OK)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return status;
-    }
-
-    status = INA231_ReadRegister(hi2c, dev_addr_7bit, INA231_REG_CONFIG, &readback);
-    if (status != HAL_OK || readback != INA231_CONFIG_VAL)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return HAL_ERROR;
-    }
-
-    return HAL_OK;
-}
-
-HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
-{
-    UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
-               INA231_I2C_ADDRESS, (hi2c == &hi2c2) ? 2 : (hi2c == &hi2c3) ? 3 : 1);
-
-    /* PE13 power is enabled during GPIO init in main.c. */
-    tx_thread_sleep(2);
-    UartPrint("Battery: PE13 power assumed enabled\r\n");
-    (void)hi2c;
-    g_ina231_addr_7bit = INA231_I2C_ADDRESS;
-    UartPrint("Battery: Startup safe mode - probe deferred to runtime reads\r\n");
-    return HAL_OK;
-}
-
-HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
-{
-    uint8_t buf[2];
-    HAL_StatusTypeDef status;
-    static uint32_t read_fail_count = 0u;
-
-    if (hi2c == NULL || hi2c->Instance == NULL || voltage == NULL || percentage == NULL)
-    {
-        UartPrint("Battery: read invalid args\r\n");
-        return HAL_ERROR;
-    }
-
-    /* Read bus voltage register (0x02) */
-    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_BUS_V, buf, 2);
-    if (status != HAL_OK)
-    {
-        read_fail_count++;
-        if ((read_fail_count % 25u) == 0u)
-        {
-            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n",
-                       (unsigned int)g_ina231_addr_7bit,
-                       (unsigned long)HAL_I2C_GetError(hi2c));
-        }
-    }
-
-    if (status != HAL_OK)
-    {
-        *voltage = 0.0f;
-        *percentage = 0;
-        return HAL_ERROR;
-    }
-
-    {
-        uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-        *voltage = bus_raw * 1.25e-3f;
-    }
-
-    *percentage = BatteryPercentFrom2SVoltage(*voltage);
-    return HAL_OK;
-}
-
-static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
-{
-    uint8_t buf[2];
-    HAL_StatusTypeDef status;
-    const uint16_t dev_addr = (uint16_t)(0x41u << 1);
-
-    if (voltage == NULL || percentage == NULL) return HAL_ERROR;
-
-    status = SensorI2cMemRead(hi2c, dev_addr, INA231_REG_BUS_V, buf, 2);
-
-    if (status != HAL_OK)
-    {
-        *voltage = 0.0f;
-        *percentage = 0;
-        return HAL_ERROR;
-    }
-
-    /* INA219-style bus voltage register decoding used by expansion monitor. */
-    {
-        uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-        uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
-        *voltage = voltage_bits * 0.004f;
-    }
-
-    *percentage = BatteryPercentFrom2SVoltage(*voltage);
-
-    return HAL_OK;
-}
-
-/**
- * @brief Read current from INA226 shunt resistor
- * @param hi2c I2C handle
- * @param current Pointer to store current in Amps
- * @return HAL_OK on success, HAL_ERROR on failure
- */
-HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
-{
-    uint8_t buf[2];
-    uint8_t shunt_buf[2];
-    HAL_StatusTypeDef status;
-    HAL_StatusTypeDef shunt_status;
-    static uint32_t dbg_sample_count = 0u;
-    static uint32_t dbg_fail_count = 0u;
-    const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
-    const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
-
-    if (current == NULL) return HAL_ERROR;
-
-    /* Read current register (0x04) for diagnostics/comparison only */
-    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_CURRENT, buf, 2);
-    if (status != HAL_OK)
-    {
-        buf[0] = 0u;
-        buf[1] = 0u;
-    }
-
-    /* Read shunt register (0x01) and compute current directly: I = Vshunt / Rshunt */
-    shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_SHUNT_V, shunt_buf, 2);
-    if (shunt_status != HAL_OK)
-    {
-        *current = 0.0f;
-        dbg_fail_count++;
-        if ((dbg_fail_count % 25u) == 0u)
-        {
-            UartPrintf("[INA231 CUR] shunt read fail count=%lu err=0x%08lX\r\n",
-                       (unsigned long)dbg_fail_count,
-                       (unsigned long)HAL_I2C_GetError(hi2c));
-        }
-        return HAL_ERROR;
-    }
-    int16_t current_raw = (int16_t)((buf[0] << 8) | buf[1]);
-    int16_t shunt_raw = (int16_t)((shunt_buf[0] << 8) | shunt_buf[1]);
-    *current = (shunt_raw * shunt_lsb_v) / shunt_res_ohm;
-
-    dbg_sample_count++;
-    if ((dbg_sample_count % 10u) == 0u)
-    {
-        UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n",
-                   (int)current_raw,
-                   (unsigned int)buf[0],
-                   (unsigned int)buf[1],
-                   (int)shunt_raw,
-                   (unsigned int)shunt_buf[0],
-                   (unsigned int)shunt_buf[1]);
-    }
-
-    return HAL_OK;
-}
-
-/* ============================================================================
-* Battery Sensor Thread
-* ============================================================================ */
-
 void SensorBatteryThread(ULONG initial_input)
 {
-    float               expansion_voltage;
-    float               ina_voltage;
-    uint8_t             expansion_percentage;
-    uint8_t             ina_percentage;
-    HAL_StatusTypeDef   expansion_status;
-    HAL_StatusTypeDef   ina_status;
-    HAL_StatusTypeDef   current_status;
-    uint32_t            error_count = 0;
-    static ULONG        last_send_time = 0;
-    static const ULONG  SEND_INTERVAL_TICKS = 100; /* 1 second @ 100Hz ThreadX tick */
-    static const ULONG  POLL_INTERVAL_TICKS = 20;  /* 200ms polling to keep cadence accurate */
-    static const ULONG  INA_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
-    float               last_ina_voltage = 0.0f;
-    uint8_t             last_ina_percentage = 0u;
-    float               last_current_amps = 0.0f;
-    bool                have_ina_sample = false;
-    ULONG               last_ina_ok_time = 0;
-    uint32_t            loop_count = 0;
-    ULONG               last_current_sample_time = 0;
+    /* External assumes */
+    extern I2C_HandleTypeDef hi2c3;
+
+    float expansion_voltage;
+    float ina_voltage;
+    uint8_t expansion_percentage;
+    uint8_t ina_percentage;
+    
+    HAL_StatusTypeDef expansion_status;
+    HAL_StatusTypeDef ina_status;
+    HAL_StatusTypeDef current_status;
+    
+    uint32_t error_count = 0;
+    static ULONG last_send_time = 0;
+    
+    static const ULONG SEND_INTERVAL_TICKS = 100; /* 1 second @ 100Hz ThreadX tick */
+    static const ULONG POLL_INTERVAL_TICKS = 20;  /* 200ms polling to keep cadence accurate */
+    static const ULONG INA_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    
+    float last_ina_voltage = 0.0f;
+    uint8_t last_ina_percentage = 0u;
+    float last_current_amps = 0.0f;
+    bool have_ina_sample = false;
+    ULONG last_ina_ok_time = 0;
+    uint32_t loop_count = 0;
+    ULONG last_current_sample_time = 0;
 
     (void)initial_input;
+    (void)INA_STALE_TIMEOUT_TICKS;
+    (void)have_ina_sample;
+    (void)last_ina_ok_time;
+    (void)last_current_sample_time;
+
     UartPrint("Battery Thread: Started\r\n");
     last_send_time = tx_time_get();
-    if (last_send_time >= SEND_INTERVAL_TICKS)
-        last_send_time -= SEND_INTERVAL_TICKS;
-    else
-        last_send_time = 0;
+    
+    if (last_send_time >= SEND_INTERVAL_TICKS) last_send_time -= SEND_INTERVAL_TICKS;
+    else last_send_time = 0;
+    
     last_ina_ok_time = last_send_time;
     last_current_sample_time = last_send_time;
 
     /* Give the system 2 seconds to settle exactly as before */
     tx_thread_sleep(200);
 
-    /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
+    /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) */
     if (Battery_Init(&hi2c2) != HAL_OK) {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_battery_power_ready = true;
@@ -695,11 +815,10 @@ void SensorBatteryThread(ULONG initial_input)
         float current_amps = 0.0f;
         ULONG current_time = tx_time_get();
         loop_count++;
+        
         if ((loop_count % 250u) == 0u)
         {
-            UartPrintf("[BATTERY LOOP] alive=%lu tick=%lu\r\n",
-                       (unsigned long)loop_count,
-                       (unsigned long)current_time);
+            UartPrintf("[BATTERY LOOP] alive=%lu tick=%lu\r\n", (unsigned long)loop_count, (unsigned long)current_time);
         }
 
         (void)last_send_time;
@@ -716,6 +835,7 @@ void SensorBatteryThread(ULONG initial_input)
             last_ina_percentage = ina_percentage;
             have_ina_sample = true;
             last_ina_ok_time = current_time;
+            
             current_status = Battery_ReadCurrent(&hi2c2, &current_amps);
             if (current_status == HAL_OK)
             {
@@ -735,6 +855,7 @@ void SensorBatteryThread(ULONG initial_input)
                 g_ina231_data.percentage = last_ina_percentage;
                 g_ina231_data.timestamp = current_time;
                 g_ina231_data.data_valid = 1u;
+                
                 if (expansion_status == HAL_OK)
                 {
                     g_battery_data.voltage = expansion_voltage;
@@ -771,12 +892,29 @@ void SensorBatteryThread(ULONG initial_input)
     }
 }
 
-/* ============================================================================
- * INA231 Sensor Thread (DISABLED / SLEEPING FOREVER)
- * ============================================================================ */
-
+/**
+ * @brief  ThreadX entry function for generic INA231 tasks (currently sleeps).
+ * @param  initial_input ThreadX parameter (unused).
+ */
 void SensorINA231Thread(ULONG initial_input)
 {
     (void)initial_input;
     while (1) { tx_thread_sleep(TX_WAIT_FOREVER); }
+}
+
+/* ============================================================================
+ * Initialization
+ * ============================================================================ */
+
+/**
+ * @brief  Initialize sensor data structures and mutexes.
+ */
+void SensorsInit(void)
+{
+    tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
+    tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
+    
+    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
+    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
+    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
 }

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -30,19 +30,8 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
 static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
 
-static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
-static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c);
-
-/* ============================================================================
- * Global variables declaration
- * ============================================================================ */
-
-TX_MUTEX             g_sensorDataMutex;
-HTS221_Data_t        g_hts221Data;
-Battery_Data_t       g_batteryData;
-I2C_HandleTypeDef    g_hi2c2;
-INA231_Data_t        g_ina231Data;
-TX_MUTEX             g_i2cMutex;
+static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
+static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
 
 /* ============================================================================
  * Initialization
@@ -72,7 +61,7 @@ void SensorsInit(void)
  * @param  mem_addr Internal memory address
  * @param  buf Data buffer
  * @param  len Length
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len)
 {
@@ -117,7 +106,7 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_
  * @param  mem_addr Internal memory address
  * @param  buf Data buffer
  * @param  len Length
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len)
 {
@@ -156,9 +145,9 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
  * @param  hi2c I2C handle
  * @param  reg Register address
  * @param  data Byte to write
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
+static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
 {
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     return SensorI2cMemWrite(hi2c, addr, reg, &data, 1);
@@ -167,16 +156,16 @@ static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, ui
 /**
  * @brief  Read calibration data from HTS221.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c)
+static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
 {
     uint8_t t0_msb, t1_msb;
     uint8_t buffer[16];
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
 
-    if (status != HAL_OK)
+    if (status != HAL_OK) 
         return HAL_ERROR;
 
     calib_data.H0_rh = buffer[0] >> 1;
@@ -197,7 +186,7 @@ static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c)
 /**
  * @brief  Initialize HTS221 sensor.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
 {
@@ -206,12 +195,12 @@ HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
         UartPrint("HTS221: init null I2C handle\r\n");
         return HAL_ERROR;
     }
-    if (HTS221WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
+    if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
     {
         UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
         return HAL_ERROR;
     }
-    if (HTS221ReadCalibration(hi2c) != HAL_OK)
+    if (HTS221_ReadCalibration(hi2c) != HAL_OK)
     {
         UartPrint("HTS221: Failed to read calibration\r\n");
         return HAL_ERROR;
@@ -226,7 +215,7 @@ HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
  * @param  hi2c I2C handle
  * @param  temperature Output float reference
  * @param  humidity Output float reference
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity)
 {
@@ -279,7 +268,7 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
 /**
  * @brief  Calculate 2S battery percentage.
  * @param  voltage_v Input voltage
- * @return uint8_t
+ * @return uint8_t 
  */
 static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 {
@@ -305,7 +294,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
     {
         pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
     }
-    if (pct < 0.0f)
+    if (pct < 0.0f) 
     {
         pct = 0.0f;
     }
@@ -319,7 +308,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 /**
  * @brief  Initialize Battery monitor functionality.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef BatteryInit(I2C_HandleTypeDef *hi2c)
 {
@@ -339,7 +328,7 @@ HAL_StatusTypeDef BatteryInit(I2C_HandleTypeDef *hi2c)
  * @param  hi2c I2C handle
  * @param  voltage Output pointer
  * @param  percentage Output pointer
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -382,7 +371,7 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
  * @param  hi2c I2C handle
  * @param  voltage Output pointer
  * @param  percentage Output pointer
- * @return HAL_StatusTypeDef
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -390,7 +379,7 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
     HAL_StatusTypeDef status;
     const uint16_t dev_addr = (uint16_t)(0x41u << 1);
 
-    if (voltage == NULL || percentage == NULL)
+    if (voltage == NULL || percentage == NULL) 
     {
         return HAL_ERROR;
     }
@@ -429,7 +418,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
     const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
 
-    if (current == NULL)
+    if (current == NULL) 
     {
         return HAL_ERROR;
     }
@@ -468,11 +457,9 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     return HAL_OK;
 }
 
-
 /* ============================================================================
  * Thread Definitions
  * ============================================================================ */
-
 /**
  * @brief Thread entry for HTS221 lifecycle and sampling.
  * @param initial_input Thread argument
@@ -480,139 +467,103 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
 void SensorHTS221Thread(ULONG initial_input)
 {
     float temp, hum;
-    float last_temp = 0.0f, last_hum = 0.0f;
-    HAL_StatusTypeDef   status;
-    HAL_StatusTypeDef   init_status;
-    static int16_t      last_temp_int = -99;
-    static int16_t      last_hum_int = -99;
-    static ULONG        last_send_time = 0;
-    static const ULONG  HEARTBEAT_INTERVAL = 500; /* 5 seconds @ 100Hz tick */
-    static const ULONG  HTS_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    HAL_StatusTypeDef status;
+    static int16_t last_temp_int = -99;
+    static int16_t last_hum_int = -99;
+    static ULONG last_send_time = 0;
+    static const ULONG HEARTBEAT_INTERVAL = 500;
+    static const ULONG HTS_STALE_TIMEOUT_TICKS = 1000;
     static const uint8_t HTS_REINIT_THRESHOLD = 5;
-    uint32_t            init_attempts = 0;
-    uint8_t             consecutive_failures = 0;
-    bool                hts_ready = false;
-    bool                have_sample = false;
-    ULONG               last_hts_ok_time = 0;
+
+    uint32_t init_attempts = 0;
+    uint8_t consecutive_failures = 0;
+    bool hts_ready = false;
+    ULONG last_hts_ok_time = 0;
 
     (void)initial_input;
     UartPrint("HTS221 Thread: Started\r\n");
     tx_thread_sleep(100);
 
-    while (!g_batteryPowerReady)
-    {
+    while (!g_batteryPowerReady) {
         tx_thread_sleep(50);
     }
 
-    while (!hts_ready)
-    {
-        init_status = Hts221Init(&hi2c2);
-        if (init_status == HAL_OK)
-        {
-            hts_ready = true;
-            last_send_time = tx_time_get();
-            last_hts_ok_time = last_send_time;
-            break;
-        }
-
-        init_attempts++;
-        if (init_attempts == 1 || (init_attempts % 10) == 0)
-        {
-            UartPrintf("HTS221: init retry %lu failed\r\n", (unsigned long)init_attempts);
-        }
-        tx_thread_sleep(500);
-    }
-
-    while (1)
+    while (1) 
     {
         ULONG current_time = tx_time_get();
 
+        if (!hts_ready) 
+        {
+            if (Hts221Init(&hi2c2) == HAL_OK) 
+            {
+                hts_ready = true;
+                consecutive_failures = 0;
+                last_hts_ok_time = current_time;
+                last_send_time = current_time;
+            } 
+            else 
+            {
+                init_attempts++;
+                if (init_attempts == 1 || (init_attempts % 10) == 0) {
+                    UartPrintf("HTS221: Init/Retry %lu failed\r\n", (unsigned long)init_attempts);
+                }
+                tx_thread_sleep(500);
+                continue;
+            }
+        }
+
         status = HTS221_ReadBoth(&hi2c2, &temp, &hum);
-        if (status == HAL_OK)
+
+        if (status == HAL_OK) 
         {
             consecutive_failures = 0;
-            last_temp = temp;
-            last_hum = hum;
-            have_sample = true;
             last_hts_ok_time = current_time;
-            if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
+
+            if (tx_mutex_get(&g_sensorDataMutex, 10) == TX_SUCCESS) 
             {
-                g_hts221Data.temperature = last_temp;
-                g_hts221Data.humidity = last_hum;
+                g_hts221Data.temperature = temp;
+                g_hts221Data.humidity = hum;
                 g_hts221Data.timestamp = current_time;
                 g_hts221Data.data_valid = 1;
                 tx_mutex_put(&g_sensorDataMutex);
             }
+
+            /* Lógica de Heartbeat / Envio por variação */
             int16_t temp_int = (int16_t)temp;
             int16_t hum_int = (int16_t)hum;
-
-            if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL) 
             {
-                /* Expected application integration using CanSend */
                 last_temp_int = temp_int;
                 last_hum_int = hum_int;
                 last_send_time = current_time;
             }
-        }
-        else
+        } 
+        else 
         {
-            bool hts_stale = ((current_time - last_hts_ok_time) >= HTS_STALE_TIMEOUT_TICKS);
-
-            if (hts_stale)
+            consecutive_failures++;
+            
+            if ((current_time - last_hts_ok_time) >= HTS_STALE_TIMEOUT_TICKS) 
             {
-                last_temp = 0.0f;
-                last_hum = 0.0f;
-
-                if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
+                if (tx_mutex_get(&g_sensorDataMutex, 10) == TX_SUCCESS)
                 {
-                    g_hts221Data.temperature = 0.0f;
-                    g_hts221Data.humidity = 0.0f;
-                    g_hts221Data.timestamp = current_time;
                     g_hts221Data.data_valid = 0;
                     tx_mutex_put(&g_sensorDataMutex);
                 }
             }
 
-            if (have_sample && (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (consecutive_failures >= HTS_REINIT_THRESHOLD) 
             {
-                last_send_time = current_time;
-            }
-
-            consecutive_failures++;
-            if (consecutive_failures < HTS_REINIT_THRESHOLD)
-            {
-                if (consecutive_failures == 1 || consecutive_failures == HTS_REINIT_THRESHOLD - 1)
-                {
-                    UartPrintf("HTS221: read failed (%u/%u)\r\n",
-                               (unsigned int)consecutive_failures,
-                               (unsigned int)HTS_REINIT_THRESHOLD);
-                }
-                tx_thread_sleep(100);
-                continue;
-            }
-
-            consecutive_failures = 0;
-            hts_ready = false;
-            tx_thread_sleep(500);
-
-            while (!hts_ready)
-            {
-                init_status = Hts221Init(&hi2c2);
-                if (init_status == HAL_OK)
-                {
-                    hts_ready = true;
-                    last_send_time = tx_time_get();
-                    break;
-                }
-
-                init_attempts++;
-                if (init_attempts == 1 || (init_attempts % 10) == 0)
-                {
-                    UartPrintf("HTS221: reinit retry %lu failed\r\n", (unsigned long)init_attempts);
-                }
+                UartPrintf("HTS221: Max failures reached (%u). Resetting driver...\r\n", consecutive_failures);
+                hts_ready = false; // Força re-inicialização no topo do próximo loop
                 tx_thread_sleep(500);
+            } 
+            else 
+            {
+                tx_thread_sleep(100);
             }
+            continue;
         }
+
         tx_thread_sleep(100);
     }
 }
@@ -625,7 +576,7 @@ void SensorBatteryThread(ULONG initial_input)
 {
     /* hi2c3 required for Expansion Battery */
     extern I2C_HandleTypeDef hi2c3;
-
+    
     float               expansion_voltage;
     float               ina_voltage;
     uint8_t             expansion_percentage;
@@ -651,7 +602,7 @@ void SensorBatteryThread(ULONG initial_input)
     (void)have_ina_sample;
     (void)last_ina_ok_time;
     (void)last_current_sample_time;
-
+    
     UartPrint("Battery Thread: Started\r\n");
     last_send_time = tx_time_get();
     if (last_send_time >= SEND_INTERVAL_TICKS)
@@ -669,12 +620,12 @@ void SensorBatteryThread(ULONG initial_input)
     tx_thread_sleep(200);
 
     /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
-    if (BatteryInit(&hi2c2) != HAL_OK)
+    if (BatteryInit(&hi2c2) != HAL_OK) 
     {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_batteryPowerReady = true;
-    }
-    else
+    } 
+    else 
     {
         UartPrint("Battery Thread: INA231 initialized successfully\r\n");
         g_batteryPowerReady = true;

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -480,75 +480,75 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
 void SensorHTS221Thread(ULONG initial_input)
 {
     float temp, hum;
-    float last_temp = 0.0f, last_hum = 0.0f;
-    HAL_StatusTypeDef   status;
-    HAL_StatusTypeDef   init_status;
-    static int16_t      last_temp_int = -99;
-    static int16_t      last_hum_int = -99;
-    static ULONG        last_send_time = 0;
-    static const ULONG  HEARTBEAT_INTERVAL = 500; /* 5 seconds @ 100Hz tick */
-    static const ULONG  HTS_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    HAL_StatusTypeDef status;
+    static int16_t last_temp_int = -99;
+    static int16_t last_hum_int = -99;
+    static ULONG last_send_time = 0;
+    static const ULONG HEARTBEAT_INTERVAL = 500;
+    static const ULONG HTS_STALE_TIMEOUT_TICKS = 1000;
     static const uint8_t HTS_REINIT_THRESHOLD = 5;
-    uint32_t            init_attempts = 0;
-    uint8_t             consecutive_failures = 0;
-    bool                hts_ready = false;
-    bool                have_sample = false;
-    ULONG               last_hts_ok_time = 0;
+
+    uint32_t init_attempts = 0;
+    uint8_t consecutive_failures = 0;
+    bool hts_ready = false;
+    ULONG last_hts_ok_time = 0;
 
     (void)initial_input;
     UartPrint("HTS221 Thread: Started\r\n");
     tx_thread_sleep(100);
 
-    while (!g_batteryPowerReady)
-    {
+    /* Aguarda que o barramento de potência esteja ativo */
+    while (!g_batteryPowerReady) {
         tx_thread_sleep(50);
-    }
-
-    while (!hts_ready)
-    {
-        init_status = Hts221Init(&hi2c2);
-        if (init_status == HAL_OK)
-        {
-            hts_ready = true;
-            last_send_time = tx_time_get();
-            last_hts_ok_time = last_send_time;
-            break;
-        }
-
-        init_attempts++;
-        if (init_attempts == 1 || (init_attempts % 10) == 0)
-        {
-            UartPrintf("HTS221: init retry %lu failed\r\n", (unsigned long)init_attempts);
-        }
-        tx_thread_sleep(500);
     }
 
     while (1)
     {
         ULONG current_time = tx_time_get();
 
+        /* --- Lógica de (Re)Inicialização Consolidada --- */
+        if (!hts_ready)
+        {
+            if (Hts221Init(&hi2c2) == HAL_OK)
+            {
+                hts_ready = true;
+                consecutive_failures = 0;
+                last_hts_ok_time = current_time;
+                last_send_time = current_time;
+            }
+            else
+            {
+                init_attempts++;
+                if (init_attempts == 1 || (init_attempts % 10) == 0) {
+                    UartPrintf("HTS221: Init/Retry %lu failed\r\n", (unsigned long)init_attempts);
+                }
+                tx_thread_sleep(500);
+                continue; /* Tenta novamente no próximo ciclo */
+            }
+        }
+
+        /* --- Leitura de Dados --- */
         status = HTS221_ReadBoth(&hi2c2, &temp, &hum);
+
         if (status == HAL_OK)
         {
             consecutive_failures = 0;
-            last_temp = temp;
-            last_hum = hum;
-            have_sample = true;
             last_hts_ok_time = current_time;
-            if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
+
+            if (tx_mutex_get(&g_sensorDataMutex, 10) == TX_SUCCESS)
             {
-                g_hts221Data.temperature = last_temp;
-                g_hts221Data.humidity = last_hum;
+                g_hts221Data.temperature = temp;
+                g_hts221Data.humidity = hum;
                 g_hts221Data.timestamp = current_time;
                 g_hts221Data.data_valid = 1;
                 tx_mutex_put(&g_sensorDataMutex);
             }
+
+            /* Lógica de Heartbeat / Envio por variação */
             int16_t temp_int = (int16_t)temp;
             int16_t hum_int = (int16_t)hum;
-
             if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
             {
-                /* Expected application integration using CanSend */
                 last_temp_int = temp_int;
                 last_hum_int = hum_int;
                 last_send_time = current_time;
@@ -556,64 +556,32 @@ void SensorHTS221Thread(ULONG initial_input)
         }
         else
         {
-            bool hts_stale = ((current_time - last_hts_ok_time) >= HTS_STALE_TIMEOUT_TICKS);
+            /* --- Gestão de Erros de Leitura --- */
+            consecutive_failures++;
 
-            if (hts_stale)
+            // Verifica se os dados ficaram obsoletos (stale)
+            if ((current_time - last_hts_ok_time) >= HTS_STALE_TIMEOUT_TICKS)
             {
-                last_temp = 0.0f;
-                last_hum = 0.0f;
-
-                if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
-                {
-                    g_hts221Data.temperature = 0.0f;
-                    g_hts221Data.humidity = 0.0f;
-                    g_hts221Data.timestamp = current_time;
+                if (tx_mutex_get(&g_sensorDataMutex, 10) == TX_SUCCESS) {
                     g_hts221Data.data_valid = 0;
                     tx_mutex_put(&g_sensorDataMutex);
                 }
             }
 
-            if (have_sample && (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (consecutive_failures >= HTS_REINIT_THRESHOLD)
             {
-                last_send_time = current_time;
-            }
-
-            consecutive_failures++;
-            if (consecutive_failures < HTS_REINIT_THRESHOLD)
-            {
-                if (consecutive_failures == 1 || consecutive_failures == HTS_REINIT_THRESHOLD - 1)
-                {
-                    UartPrintf("HTS221: read failed (%u/%u)\r\n",
-                               (unsigned int)consecutive_failures,
-                               (unsigned int)HTS_REINIT_THRESHOLD);
-                }
-                tx_thread_sleep(100);
-                continue;
-            }
-
-            consecutive_failures = 0;
-            hts_ready = false;
-            tx_thread_sleep(500);
-
-            while (!hts_ready)
-            {
-                init_status = Hts221Init(&hi2c2);
-                if (init_status == HAL_OK)
-                {
-                    hts_ready = true;
-                    last_send_time = tx_time_get();
-                    break;
-                }
-
-                init_attempts++;
-                if (init_attempts == 1 || (init_attempts % 10) == 0)
-                {
-                    UartPrintf("HTS221: reinit retry %lu failed\r\n", (unsigned long)init_attempts);
-                }
+                UartPrintf("HTS221: Max failures reached (%u). Resetting driver...\r\n", consecutive_failures);
+                hts_ready = false; // Força re-inicialização no topo do próximo loop
                 tx_thread_sleep(500);
             }
+            else
+            {
+                tx_thread_sleep(100);
+            }
+            continue;
         }
-        tx_thread_sleep(100);
+
+        tx_thread_sleep(100); // Sampling rate (~10Hz)
     }
 }
 

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -30,8 +30,8 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
 static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
 
-static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
-static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
+static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c);
 
 /* ============================================================================
  * Initialization
@@ -61,7 +61,7 @@ void SensorsInit(void)
  * @param  mem_addr Internal memory address
  * @param  buf Data buffer
  * @param  len Length
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len)
 {
@@ -106,7 +106,7 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_
  * @param  mem_addr Internal memory address
  * @param  buf Data buffer
  * @param  len Length
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len)
 {
@@ -145,9 +145,9 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
  * @param  hi2c I2C handle
  * @param  reg Register address
  * @param  data Byte to write
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
-static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
+static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
 {
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     return SensorI2cMemWrite(hi2c, addr, reg, &data, 1);
@@ -156,16 +156,16 @@ static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, u
 /**
  * @brief  Read calibration data from HTS221.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
-static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
+static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c)
 {
     uint8_t t0_msb, t1_msb;
     uint8_t buffer[16];
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
     HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
 
-    if (status != HAL_OK) 
+    if (status != HAL_OK)
         return HAL_ERROR;
 
     calib_data.H0_rh = buffer[0] >> 1;
@@ -186,7 +186,7 @@ static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
 /**
  * @brief  Initialize HTS221 sensor.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
 {
@@ -195,12 +195,12 @@ HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
         UartPrint("HTS221: init null I2C handle\r\n");
         return HAL_ERROR;
     }
-    if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
+    if (HTS221WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
     {
         UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
         return HAL_ERROR;
     }
-    if (HTS221_ReadCalibration(hi2c) != HAL_OK)
+    if (HTS221ReadCalibration(hi2c) != HAL_OK)
     {
         UartPrint("HTS221: Failed to read calibration\r\n");
         return HAL_ERROR;
@@ -215,7 +215,7 @@ HAL_StatusTypeDef Hts221Init(I2C_HandleTypeDef *hi2c)
  * @param  hi2c I2C handle
  * @param  temperature Output float reference
  * @param  humidity Output float reference
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity)
 {
@@ -268,7 +268,7 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
 /**
  * @brief  Calculate 2S battery percentage.
  * @param  voltage_v Input voltage
- * @return uint8_t 
+ * @return uint8_t
  */
 static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 {
@@ -294,7 +294,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
     {
         pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
     }
-    if (pct < 0.0f) 
+    if (pct < 0.0f)
     {
         pct = 0.0f;
     }
@@ -308,7 +308,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 /**
  * @brief  Initialize Battery monitor functionality.
  * @param  hi2c I2C handle
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 HAL_StatusTypeDef BatteryInit(I2C_HandleTypeDef *hi2c)
 {
@@ -328,7 +328,7 @@ HAL_StatusTypeDef BatteryInit(I2C_HandleTypeDef *hi2c)
  * @param  hi2c I2C handle
  * @param  voltage Output pointer
  * @param  percentage Output pointer
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -371,7 +371,7 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
  * @param  hi2c I2C handle
  * @param  voltage Output pointer
  * @param  percentage Output pointer
- * @return HAL_StatusTypeDef 
+ * @return HAL_StatusTypeDef
  */
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -379,7 +379,7 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
     HAL_StatusTypeDef status;
     const uint16_t dev_addr = (uint16_t)(0x41u << 1);
 
-    if (voltage == NULL || percentage == NULL) 
+    if (voltage == NULL || percentage == NULL)
     {
         return HAL_ERROR;
     }
@@ -418,7 +418,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
     const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
 
-    if (current == NULL) 
+    if (current == NULL)
     {
         return HAL_ERROR;
     }
@@ -614,7 +614,7 @@ void SensorBatteryThread(ULONG initial_input)
 {
     /* hi2c3 required for Expansion Battery */
     extern I2C_HandleTypeDef hi2c3;
-    
+
     float               expansion_voltage;
     float               ina_voltage;
     uint8_t             expansion_percentage;
@@ -640,7 +640,7 @@ void SensorBatteryThread(ULONG initial_input)
     (void)have_ina_sample;
     (void)last_ina_ok_time;
     (void)last_current_sample_time;
-    
+
     UartPrint("Battery Thread: Started\r\n");
     last_send_time = tx_time_get();
     if (last_send_time >= SEND_INTERVAL_TICKS)
@@ -658,12 +658,12 @@ void SensorBatteryThread(ULONG initial_input)
     tx_thread_sleep(200);
 
     /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
-    if (BatteryInit(&hi2c2) != HAL_OK) 
+    if (BatteryInit(&hi2c2) != HAL_OK)
     {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_batteryPowerReady = true;
-    } 
-    else 
+    }
+    else
     {
         UartPrint("Battery Thread: INA231 initialized successfully\r\n");
         g_batteryPowerReady = true;

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -34,6 +34,17 @@ static HAL_StatusTypeDef HTS221WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, ui
 static HAL_StatusTypeDef HTS221ReadCalibration(I2C_HandleTypeDef *hi2c);
 
 /* ============================================================================
+ * Global variables declaration
+ * ============================================================================ */
+
+TX_MUTEX             g_sensorDataMutex;
+HTS221_Data_t        g_hts221Data;
+Battery_Data_t       g_batteryData;
+I2C_HandleTypeDef    g_hi2c2;
+INA231_Data_t        g_ina231Data;
+TX_MUTEX             g_i2cMutex;
+
+/* ============================================================================
  * Initialization
  * ============================================================================ */
 

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -473,6 +473,23 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
  * ============================================================================ */
 /**
  * @brief Thread entry for HTS221 lifecycle and sampling.
+ * @details
+ * This thread owns the HTS221 sensor interaction and runs continuously.
+ * Its behavior is split into two phases:
+ * - Initialization/recovery: attempts to initialize the HTS221, tracking
+ *   retry attempts and consecutive failures.
+ * - Sampling/publishing: periodically reads temperature/humidity, validates
+ *   freshness, and publishes updates when values change or heartbeat timing
+ *   requires a refresh.
+ *
+ * Internal static state is used to:
+ * - avoid redundant publishes when integer-rounded values are unchanged,
+ * - enforce a heartbeat interval so downstream consumers still receive data,
+ * - detect stale sensor operation and trigger reinitialization after
+ *   repeated read failures or timeout without successful reads.
+ *
+ * Timing and retry thresholds are intentionally centralized in local constants
+ * to keep runtime behavior predictable for embedded scheduling.
  * @param initial_input Thread argument
  */
 void SensorHTS221Thread(ULONG initial_input)

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -44,9 +44,9 @@ void SensorsInit(void)
 {
     tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
     tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
-    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
-    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
-    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
+    memset(&g_hts221Data, 0, sizeof(HTS221_Data_t));
+    memset(&g_batteryData, 0, sizeof(Battery_Data_t));
+    memset(&g_ina231Data, 0, sizeof(INA231_Data_t));
 }
 
 

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -44,7 +44,6 @@ static HTS221_Calibration_t calib_data;
 /* ============================================================================
  * Private Function Prototypes
  * ============================================================================ */
-static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit);
 static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len);
 static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len);
 
@@ -53,7 +52,6 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
 
 static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value);
 static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value);
-static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit);
 
 static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
 static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
@@ -79,36 +77,6 @@ void SensorsInit(void)
 /* ============================================================================
  * I2C Abstraction Layer (Thread-Safe)
  * ============================================================================ */
-
-/**
- * @brief  Probe I2C address securely.
- * @param  hi2c I2C handle
- * @param  dev_addr_7bit 7-bit device address
- * @return HAL_StatusTypeDef 
- */
-static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
-{
-    HAL_StatusTypeDef status;
-    TX_THREAD *thread = tx_thread_identify();
-    if (hi2c == NULL || hi2c->Instance == NULL)
-    {
-        UartPrint("[I2C GUARD] probe null handle\r\n");
-        return HAL_ERROR;
-    }
-
-    if (thread)
-    {
-        if (tx_mutex_get(&g_i2cMutex, SENSOR_I2C_MUTEX_TIMEOUT_TICKS) != TX_SUCCESS)
-            return HAL_BUSY;
-    }
-
-    status = HAL_I2C_IsDeviceReady(hi2c, (uint16_t)(dev_addr_7bit << 1), 1, SENSOR_I2C_TIMEOUT_MS);
-
-    if (thread)
-        tx_mutex_put(&g_i2cMutex);
-
-    return status;
-}
 
 /**
  * @brief  Read from I2C memory securely.
@@ -402,44 +370,6 @@ static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t de
         return status;
 
     *value = (uint16_t)((buf[0] << 8) | buf[1]);
-    return HAL_OK;
-}
-
-/**
- * @brief  Configure INA231 logic.
- * @param  hi2c I2C handle
- * @param  dev_addr_7bit Target device address
- * @return HAL_StatusTypeDef 
- */
-static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
-{
-    uint8_t prev_addr = g_ina231_addr_7bit;
-    uint16_t readback = 0u;
-    HAL_StatusTypeDef status;
-
-    g_ina231_addr_7bit = dev_addr_7bit;
-
-    status = INA231_WriteRegister(hi2c, INA219_REG_CONFIG, 0x4127); /* Replace with correct INA231 config if defined */
-    if (status != HAL_OK)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return status;
-    }
-
-    status = INA231_WriteRegister(hi2c, INA219_REG_CALIBRATION, 0x0A00); /* Replace with correct INA231 calib if defined */
-    if (status != HAL_OK)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return status;
-    }
-
-    status = INA231_ReadRegister(hi2c, dev_addr_7bit, INA219_REG_CONFIG, &readback);
-    if (status != HAL_OK || readback != 0x4127)
-    {
-        g_ina231_addr_7bit = prev_addr;
-        return HAL_ERROR;
-    }
-
     return HAL_OK;
 }
 

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -2,181 +2,406 @@
  ******************************************************************************
 * @file           : sensors.c
 * @brief          : Sensor threads management and drivers
-* @details        : Each sensor runs in its own thread to collect telemetry
-*                   data for the Qt HMI application
-*                   Includes HTS221 driver implementation
+* @details        : Exact port of bare-metal INA231 logic to ThreadX
 ******************************************************************************
 */
 
 #include "sensors.h"
+#include <string.h>
+#include <math.h>
 
-TX_MUTEX 					g_sensorDataMutex;
-HTS221_Data_t				g_hts221_data;
-Battery_Data_t				g_battery_data;
+/* Fallback for external functions if not in headers */
+extern void UartPrint(const char* msg);
+extern void UartPrintf(const char* format, ...);
+extern void SoftwareDelay(uint32_t ms);
+
+TX_MUTEX                    g_sensorDataMutex;
+TX_MUTEX                    g_i2cMutex; /* Hardware lock for the I2C2 Bus */
+static volatile bool        g_battery_power_ready = false;
+static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+
+HTS221_Data_t               g_hts221_data;
+Battery_Data_t              g_battery_data;
+INA231_Data_t               g_ina231_data;
+
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
+                                          uint16_t dev_addr,
+                                          uint16_t mem_addr,
+                                          uint8_t *buf,
+                                          uint16_t len);
+
+static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
+{
+    /* SOC calibration for the deployed 2S2P pack under load. */
+    const float soc_max_v = 8.15f;
+    const float soc_nom_v = 7.40f;
+    const float soc_min_v = 6.00f;
+    float pct = 0.0f;
+
+    if (voltage_v >= soc_max_v) {
+        return 100u;
+    }
+    if (voltage_v <= soc_min_v) {
+        return 0u;
+    }
+    if (voltage_v >= soc_nom_v) {
+        pct = 50.0f + ((voltage_v - soc_nom_v) / (soc_max_v - soc_nom_v)) * 50.0f;
+    } else {
+        pct = ((voltage_v - soc_min_v) / (soc_nom_v - soc_min_v)) * 50.0f;
+    }
+
+    if (pct < 0.0f) pct = 0.0f;
+    if (pct > 100.0f) pct = 100.0f;
+    return (uint8_t)(pct + 0.5f);
+}
 static HTS221_Calibration_t calib_data;
-/**
- * @brief Write a register on the HTS221 sensor.
- *
- * @param hi2c I2C bus handle.
- * @param reg Register address.
- * @param data Value to write.
- * @return HAL status code.
- */
+
+static const ULONG SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
+static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
+
+static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
+{
+    HAL_StatusTypeDef status;
+    TX_THREAD *thread = tx_thread_identify();
+    if (hi2c == NULL || hi2c->Instance == NULL)
+    {
+        UartPrint("[I2C GUARD] probe null handle\r\n");
+        return HAL_ERROR;
+    }
+
+    if (thread)
+    {
+        if (tx_mutex_get(&g_i2cMutex, SENSOR_I2C_MUTEX_TIMEOUT_TICKS) != TX_SUCCESS)
+            return HAL_BUSY;
+    }
+
+    status = HAL_I2C_IsDeviceReady(hi2c, (uint16_t)(dev_addr_7bit << 1), 1, SENSOR_I2C_TIMEOUT_MS);
+
+    if (thread)
+        tx_mutex_put(&g_i2cMutex);
+
+    return status;
+}
+
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
+                                          uint16_t dev_addr,
+                                          uint16_t mem_addr,
+                                          uint8_t *buf,
+                                          uint16_t len)
+{
+    HAL_StatusTypeDef status;
+    TX_THREAD *thread = tx_thread_identify();
+    uint8_t reg_addr = (uint8_t)(mem_addr & 0xFFu);
+    if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
+    {
+        UartPrint("[I2C GUARD] mem read invalid args\r\n");
+        return HAL_ERROR;
+    }
+
+    if (thread)
+    {
+        if (tx_mutex_get(&g_i2cMutex, SENSOR_I2C_MUTEX_TIMEOUT_TICKS) != TX_SUCCESS)
+            return HAL_BUSY;
+    }
+
+    status = HAL_I2C_Mem_Read(hi2c,
+                              dev_addr,
+                              mem_addr,
+                              I2C_MEMADD_SIZE_8BIT,
+                              buf,
+                              len,
+                              SENSOR_I2C_TIMEOUT_MS);
+
+    if (status != HAL_OK)
+    {
+        /* Fallback path for devices that prefer register-pointer write + read sequence. */
+        status = HAL_I2C_Master_Transmit(hi2c, dev_addr, &reg_addr, 1, SENSOR_I2C_TIMEOUT_MS);
+        if (status == HAL_OK)
+        {
+            status = HAL_I2C_Master_Receive(hi2c, dev_addr, buf, len, SENSOR_I2C_TIMEOUT_MS);
+        }
+    }
+
+    if (thread) tx_mutex_put(&g_i2cMutex);
+    return status;
+}
+
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
+                                           uint16_t dev_addr,
+                                           uint16_t mem_addr,
+                                           const uint8_t *buf,
+                                           uint16_t len)
+{
+    HAL_StatusTypeDef status;
+    TX_THREAD *thread = tx_thread_identify();
+    if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
+    {
+        UartPrint("[I2C GUARD] mem write invalid args\r\n");
+        return HAL_ERROR;
+    }
+
+    if (thread)
+    {
+        if (tx_mutex_get(&g_i2cMutex, SENSOR_I2C_MUTEX_TIMEOUT_TICKS) != TX_SUCCESS)
+            return HAL_BUSY;
+    }
+
+    status = HAL_I2C_Mem_Write(hi2c,
+                               dev_addr,
+                               mem_addr,
+                               I2C_MEMADD_SIZE_8BIT,
+                               (uint8_t *)buf,
+                               len,
+                               SENSOR_I2C_TIMEOUT_MS);
+
+    if (thread) tx_mutex_put(&g_i2cMutex);
+    return status;
+}
+
+/* ============================================================================
+ * HTS221 Driver Implementation (Thread-Safe)
+ * ============================================================================ */
+
 static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
 {
-	uint16_t addr = HTS221_I2C_ADDRESS << 1;
-	return HAL_I2C_Mem_Write(hi2c, addr, reg, I2C_MEMADD_SIZE_8BIT, &data, 1, 100);
+    uint16_t addr = HTS221_I2C_ADDRESS << 1;
+    return SensorI2cMemWrite(hi2c, addr, reg, &data, 1);
 }
 
-/**
- * @brief Read and cache calibration data from the HTS221 sensor.
- *
- * @param hi2c I2C bus handle.
- * @return HAL status code.
- */
 static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
 {
-	uint8_t t0_msb, t1_msb;
-	uint8_t buffer[16];
-	uint16_t addr = HTS221_I2C_ADDRESS << 1;
-	
-	if (HAL_I2C_Mem_Read(hi2c, addr, 0x30 | 0x80, I2C_MEMADD_SIZE_8BIT, buffer, 16, 100) != HAL_OK)
-		return HAL_ERROR; 
-	calib_data.H0_rh = buffer[0] >> 1;
-	calib_data.H1_rh = buffer[1] >> 1;
-	calib_data.T0_degC = buffer[2];
-	calib_data.T1_degC = buffer[3];
-	t0_msb = (buffer[5] & 0x03);
-	t1_msb = (buffer[5] & 0x0C) >> 2;
-	calib_data.T0_degC = ((t0_msb << 8) | calib_data.T0_degC) >> 3;
-	calib_data.T1_degC = ((t1_msb << 8) | calib_data.T1_degC) >> 3;
-	calib_data.H0_T0_out = (int16_t)(buffer[6] | (buffer[7] << 8));
-	calib_data.H1_T0_out = (int16_t)(buffer[8] | (buffer[9] << 8));
-	calib_data.T0_out = (int16_t)(buffer[12] | (buffer[13] << 8));
-	calib_data.T1_out = (int16_t)(buffer[14] | (buffer[15] << 8));
-	return HAL_OK;
+    uint8_t t0_msb, t1_msb;
+    uint8_t buffer[16];
+    uint16_t addr = HTS221_I2C_ADDRESS << 1;
+    HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
+
+    if (status != HAL_OK) return HAL_ERROR;
+
+    calib_data.H0_rh = buffer[0] >> 1;
+    calib_data.H1_rh = buffer[1] >> 1;
+    calib_data.T0_degC = buffer[2];
+    calib_data.T1_degC = buffer[3];
+    t0_msb = (buffer[5] & 0x03);
+    t1_msb = (buffer[5] & 0x0C) >> 2;
+    calib_data.T0_degC = ((t0_msb << 8) | calib_data.T0_degC) >> 3;
+    calib_data.T1_degC = ((t1_msb << 8) | calib_data.T1_degC) >> 3;
+    calib_data.H0_T0_out = (int16_t)(buffer[6] | (buffer[7] << 8));
+    calib_data.H1_T0_out = (int16_t)(buffer[8] | (buffer[9] << 8));
+    calib_data.T0_out = (int16_t)(buffer[12] | (buffer[13] << 8));
+    calib_data.T1_out = (int16_t)(buffer[14] | (buffer[15] << 8));
+    return HAL_OK;
 }
 
-/**
- * @brief Initialize HTS221 with required configuration and calibration.
- *
- * @param hi2c I2C bus handle.
- * @return HAL status code.
- */
 HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
-{   
-	if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
-	{
-		UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
-		return HAL_ERROR;
-	}
-	if (HTS221_ReadCalibration(hi2c) != HAL_OK)
-	{
-		UartPrint("HTS221: Failed to read calibration\r\n");
-		return HAL_ERROR;
-	}
-	UartPrint("HTS221: Initialized successfully\r\n");
-	SoftwareDelay(500);
-	return HAL_OK;
+{
+    if (hi2c == NULL || hi2c->Instance == NULL)
+    {
+        UartPrint("HTS221: init null I2C handle\r\n");
+        return HAL_ERROR;
+    }
+    if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
+    {
+        UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
+        return HAL_ERROR;
+    }
+    if (HTS221_ReadCalibration(hi2c) != HAL_OK)
+    {
+        UartPrint("HTS221: Failed to read calibration\r\n");
+        return HAL_ERROR;
+    }
+    UartPrint("HTS221: Initialized successfully\r\n");
+    SoftwareDelay(500);
+    return HAL_OK;
 }
 
-/**
- * @brief Read temperature and humidity from the HTS221 sensor.
- *
- * @param hi2c I2C bus handle.
- * @param temperature Output temperature value in degrees C.
- * @param humidity Output relative humidity percentage.
- * @return HAL status code.
- */
 HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity)
 {
-	uint8_t h_low, t_low, t_high;
-	int16_t h_raw, t_raw;
-	uint16_t addr = HTS221_I2C_ADDRESS << 1;
-	
-	if (HAL_I2C_Mem_Read(hi2c, addr, HTS221_HUMIDITY_OUT_L, I2C_MEMADD_SIZE_8BIT, &h_low, 1, 100) != HAL_OK)
-		return HAL_ERROR; 
-	if (HAL_I2C_Mem_Read(hi2c, addr, HTS221_TEMP_OUT_L, I2C_MEMADD_SIZE_8BIT, &t_low, 1, 100) != HAL_OK)
-		return HAL_ERROR;
-	if (HAL_I2C_Mem_Read(hi2c, addr, HTS221_TEMP_OUT_H, I2C_MEMADD_SIZE_8BIT, &t_high, 1, 100) != HAL_OK)
-		return HAL_ERROR;
+    if (hi2c == NULL || hi2c->Instance == NULL || temperature == NULL || humidity == NULL)
+    {
+        UartPrint("HTS221: read invalid args\r\n");
+        return HAL_ERROR;
+    }
+    uint8_t h_low, t_low, t_high;
+    int16_t h_raw, t_raw;
+    uint16_t addr = HTS221_I2C_ADDRESS << 1;
+    if (SensorI2cMemRead(hi2c, addr, HTS221_HUMIDITY_OUT_L, &h_low, 1) != HAL_OK) return HAL_ERROR;
+    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_L, &t_low, 1) != HAL_OK) return HAL_ERROR;
+    if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_H, &t_high, 1) != HAL_OK) return HAL_ERROR;
 
-	h_raw = (int8_t)h_low;
-	t_raw = (int16_t)(t_low | (t_high << 8));
-	
-	float t_temp = (float)(t_raw - calib_data.T0_out) * (float)(calib_data.T1_degC - calib_data.T0_degC) / 
-				(float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
-	float h_temp = ((float)(h_raw - calib_data.H0_T0_out)) * ((float)(calib_data.H1_rh - calib_data.H0_rh)) / 
-				((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
-	if (h_temp < 0.0f) h_temp = 0.0f;
-	if (h_temp > 100.0f) h_temp = 100.0f;
-	*temperature = t_temp;
-	*humidity = h_temp;
-	return HAL_OK;
+    h_raw = (int8_t)h_low;
+    t_raw = (int16_t)(t_low | (t_high << 8));
+
+    float t_temp = (float)(t_raw - calib_data.T0_out) * (float)(calib_data.T1_degC - calib_data.T0_degC) /
+                (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
+    float h_temp = ((float)(h_raw - calib_data.H0_T0_out)) * ((float)(calib_data.H1_rh - calib_data.H0_rh)) /
+                ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
+    if (h_temp < 0.0f) h_temp = 0.0f;
+    if (h_temp > 100.0f) h_temp = 100.0f;
+    *temperature = t_temp;
+    *humidity = h_temp;
+    return HAL_OK;
 }
 
-/**
- * @brief Thread entry that samples HTS221 and publishes data.
- *
- * @param initial_input ThreadX initial input (unused).
- */
 void SensorHTS221Thread(ULONG initial_input)
 {
-	float temp, hum;
-	HAL_StatusTypeDef	status;
-	static int16_t		last_temp_int = -99;
-	static int16_t		last_hum_int = -99;
-	static ULONG		last_send_time = 0;
-	static const ULONG	HEARTBEAT_INTERVAL = 3000;
-	
-	(void)initial_input;
-	UartPrint("HTS221 Thread: Started\r\n");
-	tx_thread_sleep(100);
-	last_send_time = tx_time_get();
-	
-	while (1)
-	{
-		status = HTS221_ReadBoth(&hi2c2, &temp, &hum);   
-		if (status == HAL_OK)
-		{
-			if (tx_mutex_get(&g_sensorDataMutex, TX_WAIT_FOREVER) == TX_SUCCESS)
-			{
-				g_hts221_data.temperature = temp;
-				g_hts221_data.humidity = hum;
-				g_hts221_data.timestamp = tx_time_get();
-				g_hts221_data.data_valid = 1;
-				tx_mutex_put(&g_sensorDataMutex);
-			}
-			int16_t temp_int = (int16_t)temp;
-			int16_t hum_int = (int16_t)hum;
-			ULONG current_time = tx_time_get();
+    float temp, hum;
+    float last_temp = 0.0f, last_hum = 0.0f;
+    HAL_StatusTypeDef   status;
+    HAL_StatusTypeDef   init_status;
+    static int16_t      last_temp_int = -99;
+    static int16_t      last_hum_int = -99;
+    static ULONG        last_send_time = 0;
+    static const ULONG  HEARTBEAT_INTERVAL = 500; /* 5 seconds @ 100Hz tick */
+    static const ULONG  HTS_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    static const uint8_t HTS_REINIT_THRESHOLD = 5;
+    uint32_t            init_attempts = 0;
+    uint8_t             consecutive_failures = 0;
+    bool                hts_ready = false;
+    bool                have_sample = false;
+    ULONG               last_hts_ok_time = 0;
 
-			if (temp_int != last_temp_int || hum_int != last_hum_int || 
-				(current_time - last_send_time) >= HEARTBEAT_INTERVAL)
-			{
-				t_can_message msg;
-				memset(&msg, 0, sizeof(msg));
-				msg.id = CAN_ID_HTS221_DATA;
-				msg.len = 8;
-				memcpy(&msg.data[0], &temp, 4);
-				memcpy(&msg.data[4], &hum, 4);
-				CanSend(&msg);
-				last_temp_int = temp_int;
-				last_hum_int = hum_int;
-				last_send_time = current_time;
-			}  
-		}
-		else
-		{
-			UartPrint("HTS221 Thread: Read error\r\n");
-			if (tx_mutex_get(&g_sensorDataMutex, TX_WAIT_FOREVER) == TX_SUCCESS)
-			{
-				g_hts221_data.data_valid = 0;
-				tx_mutex_put(&g_sensorDataMutex);
-			}
-		}
-		tx_thread_sleep(1000);
-	}
+    (void)initial_input;
+    UartPrint("HTS221 Thread: Started\r\n");
+    tx_thread_sleep(100);
+
+    while (!g_battery_power_ready)
+    {
+        tx_thread_sleep(50);
+    }
+
+    while (!hts_ready)
+    {
+        init_status = HTS221_Init(&hi2c2);
+        if (init_status == HAL_OK)
+        {
+            hts_ready = true;
+            last_send_time = tx_time_get();
+            last_hts_ok_time = last_send_time;
+            break;
+        }
+
+        init_attempts++;
+        if (init_attempts == 1 || (init_attempts % 10) == 0)
+        {
+            UartPrintf("HTS221: init retry %lu failed\r\n", (unsigned long)init_attempts);
+        }
+        tx_thread_sleep(500);
+    }
+
+    while (1)
+    {
+        ULONG current_time = tx_time_get();
+
+        status = HTS221_ReadBoth(&hi2c2, &temp, &hum);
+        if (status == HAL_OK)
+        {
+            consecutive_failures = 0;
+            last_temp = temp;
+            last_hum = hum;
+            have_sample = true;
+            last_hts_ok_time = current_time;
+            if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+            {
+                g_hts221_data.temperature = last_temp;
+                g_hts221_data.humidity = last_hum;
+                g_hts221_data.timestamp = current_time;
+                g_hts221_data.data_valid = 1;
+                tx_mutex_put(&g_sensorDataMutex);
+            }
+            int16_t temp_int = (int16_t)temp;
+            int16_t hum_int = (int16_t)hum;
+
+            if (temp_int != last_temp_int || hum_int != last_hum_int ||
+                (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            {
+                t_can_message msg;
+                memset(&msg, 0, sizeof(msg));
+                msg.id = CAN_ID_HTS221_DATA;
+                msg.len = 8;
+                memcpy(&msg.data[0], &last_temp, 4);
+                memcpy(&msg.data[4], &last_hum, 4);
+                if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
+                {
+                    CanSend(&msg);
+                    tx_mutex_put(&g_canMutex);
+                }
+                last_temp_int = temp_int;
+                last_hum_int = hum_int;
+                last_send_time = current_time;
+            }
+        }
+        else
+        {
+            bool hts_stale = ((current_time - last_hts_ok_time) >= HTS_STALE_TIMEOUT_TICKS);
+
+            if (hts_stale)
+            {
+                last_temp = 0.0f;
+                last_hum = 0.0f;
+
+                if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+                {
+                    g_hts221_data.temperature = 0.0f;
+                    g_hts221_data.humidity = 0.0f;
+                    g_hts221_data.timestamp = current_time;
+                    g_hts221_data.data_valid = 0;
+                    tx_mutex_put(&g_sensorDataMutex);
+                }
+            }
+
+            if (have_sample && (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            {
+                t_can_message msg;
+                memset(&msg, 0, sizeof(msg));
+                msg.id = CAN_ID_HTS221_DATA;
+                msg.len = 8;
+                memcpy(&msg.data[0], &last_temp, 4);
+                memcpy(&msg.data[4], &last_hum, 4);
+                if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
+                {
+                    CanSend(&msg);
+                    tx_mutex_put(&g_canMutex);
+                }
+                last_send_time = current_time;
+            }
+
+            consecutive_failures++;
+            if (consecutive_failures < HTS_REINIT_THRESHOLD)
+            {
+                if (consecutive_failures == 1 || consecutive_failures == HTS_REINIT_THRESHOLD - 1)
+                {
+                    UartPrintf("HTS221: read failed (%u/%u)\r\n",
+                               (unsigned int)consecutive_failures,
+                               (unsigned int)HTS_REINIT_THRESHOLD);
+                }
+                tx_thread_sleep(100);
+                continue;
+            }
+
+            consecutive_failures = 0;
+            hts_ready = false;
+            tx_thread_sleep(500);
+
+            while (!hts_ready)
+            {
+                init_status = HTS221_Init(&hi2c2);
+                if (init_status == HAL_OK)
+                {
+                    hts_ready = true;
+                    last_send_time = tx_time_get();
+                    break;
+                }
+
+                init_attempts++;
+                if (init_attempts == 1 || (init_attempts % 10) == 0)
+                {
+                    UartPrintf("HTS221: reinit retry %lu failed\r\n", (unsigned long)init_attempts);
+                }
+                tx_thread_sleep(500);
+            }
+        }
+        tx_thread_sleep(100);
+    }
 }
 
 /**
@@ -184,175 +409,374 @@ void SensorHTS221Thread(ULONG initial_input)
  */
 void SensorsInit(void)
 {
-	tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_NO_INHERIT);
-	memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
-	memset(&g_battery_data, 0, sizeof(Battery_Data_t));
+    tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
+    tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
+    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
+    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
+    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
 }
 
 /* ============================================================================
-* Battery Monitor Driver Implementation
+* Exact Port of bare-metal INA231 logic to RTOS
 * ============================================================================ */
 
-/**
- * @brief Initialize the INA219 battery monitor.
- *
- * @param hi2c I2C bus handle.
- * @return HAL status code.
- */
+static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value)
+{
+    uint8_t data[2];
+    HAL_StatusTypeDef status;
+
+    data[0] = (uint8_t)((value >> 8) & 0xFF);   // MSB
+    data[1] = (uint8_t)(value & 0xFF);          // LSB
+
+    /* Use detected INA231 address shifted to 8-bit */
+    status = SensorI2cMemWrite(hi2c,
+                               (uint16_t)(g_ina231_addr_7bit << 1),
+                               reg,
+                               data,
+                               2);
+
+    if (status != HAL_OK)
+    {
+        uint32_t hal_err = HAL_I2C_GetError(hi2c);
+        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n",
+                   reg,
+                   status,
+                   (unsigned long)hal_err);
+    }
+
+    return status;
+}
+
+static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+
+    if (value == NULL)
+        return HAL_ERROR;
+
+    status = SensorI2cMemRead(hi2c, (uint16_t)(dev_addr_7bit << 1), reg, buf, 2);
+    if (status != HAL_OK)
+        return status;
+
+    *value = (uint16_t)((buf[0] << 8) | buf[1]);
+    return HAL_OK;
+}
+
+static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
+{
+    uint8_t prev_addr = g_ina231_addr_7bit;
+    uint16_t readback = 0u;
+    HAL_StatusTypeDef status;
+
+    g_ina231_addr_7bit = dev_addr_7bit;
+
+    status = INA231_WriteRegister(hi2c, INA231_REG_CONFIG, INA231_CONFIG_VAL);
+    if (status != HAL_OK)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return status;
+    }
+
+    status = INA231_WriteRegister(hi2c, INA231_REG_CALIBRATION, INA231_CALIB_VAL);
+    if (status != HAL_OK)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return status;
+    }
+
+    status = INA231_ReadRegister(hi2c, dev_addr_7bit, INA231_REG_CONFIG, &readback);
+    if (status != HAL_OK || readback != INA231_CONFIG_VAL)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
 HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
 {
-	uint8_t buffer[2];
-	HAL_StatusTypeDef status;
-	uint16_t dev_addr = BATTERY_I2C_ADDRESS << 1;
+    UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
+               INA231_I2C_ADDRESS, (hi2c == &hi2c2) ? 2 : (hi2c == &hi2c3) ? 3 : 1);
 
-	status = HAL_I2C_Mem_Read(hi2c, dev_addr, INA219_REG_CONFIG, 
-							I2C_MEMADD_SIZE_8BIT, buffer, 2, 100);
-	
-	if (status != HAL_OK)
-	{
-		UartPrint("Battery: ERROR - Failed to communicate with INA219\r\n");
-		return HAL_ERROR;
-	}
-	status = HAL_I2C_Mem_Read(hi2c, dev_addr, INA219_REG_BUS_V, 
-							I2C_MEMADD_SIZE_8BIT, buffer, 2, 100);
-	if (status == HAL_OK)
-	{
-		uint16_t bus_voltage_raw = (buffer[0] << 8) | buffer[1];
-		uint16_t voltage_bits = (bus_voltage_raw >> 3) & 0x1FFF;
-		float voltage = voltage_bits * 0.004f;
-		UartPrintf("Battery: INA219 initialized successfully! Current voltage: %.3fV\r\n", voltage);
-		if (voltage < 9.0f || voltage > 13.0f)
-		{
-			UartPrintf("Battery: WARNING - Voltage %.3fV outside 3S range (9.0-12.6V)\r\n", voltage);
-		}
-		return HAL_OK;
-	}
-	UartPrint("Battery: ERROR - Failed to read voltage from INA219\r\n");
-	return HAL_ERROR;
+    /* PE13 power is enabled during GPIO init in main.c. */
+    tx_thread_sleep(2);
+    UartPrint("Battery: PE13 power assumed enabled\r\n");
+    (void)hi2c;
+    g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+    UartPrint("Battery: Startup safe mode - probe deferred to runtime reads\r\n");
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+    static uint32_t read_fail_count = 0u;
+
+    if (hi2c == NULL || hi2c->Instance == NULL || voltage == NULL || percentage == NULL)
+    {
+        UartPrint("Battery: read invalid args\r\n");
+        return HAL_ERROR;
+    }
+
+    /* Read bus voltage register (0x02) */
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_BUS_V, buf, 2);
+    if (status != HAL_OK)
+    {
+        read_fail_count++;
+        if ((read_fail_count % 25u) == 0u)
+        {
+            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n",
+                       (unsigned int)g_ina231_addr_7bit,
+                       (unsigned long)HAL_I2C_GetError(hi2c));
+        }
+    }
+
+    if (status != HAL_OK)
+    {
+        *voltage = 0.0f;
+        *percentage = 0;
+        return HAL_ERROR;
+    }
+
+    {
+        uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+        *voltage = bus_raw * 1.25e-3f;
+    }
+
+    *percentage = BatteryPercentFrom2SVoltage(*voltage);
+    return HAL_OK;
+}
+
+static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
+{
+    uint8_t buf[2];
+    HAL_StatusTypeDef status;
+    const uint16_t dev_addr = (uint16_t)(0x41u << 1);
+
+    if (voltage == NULL || percentage == NULL) return HAL_ERROR;
+
+    status = SensorI2cMemRead(hi2c, dev_addr, INA231_REG_BUS_V, buf, 2);
+
+    if (status != HAL_OK)
+    {
+        *voltage = 0.0f;
+        *percentage = 0;
+        return HAL_ERROR;
+    }
+
+    /* INA219-style bus voltage register decoding used by expansion monitor. */
+    {
+        uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+        uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
+        *voltage = voltage_bits * 0.004f;
+    }
+
+    *percentage = BatteryPercentFrom2SVoltage(*voltage);
+
+    return HAL_OK;
 }
 
 /**
- * @brief Read battery voltage and charge percentage.
- *
- * @param hi2c I2C bus handle.
- * @param voltage Output battery voltage.
- * @param percentage Output charge percentage.
- * @return HAL status code.
+ * @brief Read current from INA226 shunt resistor
+ * @param hi2c I2C handle
+ * @param current Pointer to store current in Amps
+ * @return HAL_OK on success, HAL_ERROR on failure
  */
-HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
+HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
 {
-	uint8_t buffer[2];
-	HAL_StatusTypeDef status;
-	uint16_t dev_addr = BATTERY_I2C_ADDRESS << 1;
-	
-	if (voltage == NULL || percentage == NULL)
-	{
-		return HAL_ERROR;
-	}
-	status = HAL_I2C_Mem_Read(hi2c, dev_addr, INA219_REG_BUS_V, 
-							I2C_MEMADD_SIZE_8BIT, buffer, 2, 100);
-	if (status != HAL_OK)
-	{
-		*voltage = 0.0f;
-		*percentage = 0;
-		return HAL_ERROR;
-	}
-	
-	/* Decode INA219 Bus Voltage Register
-	* Bit 15-3: Voltage value (LSB = 4mV)
-	* Bit 2: Reserved
-	* Bit 1: CNVR (Conversion Ready) - 1 when conversion complete
-	* Bit 0: OVF (Math Overflow) - 1 on overflow
-	*/
-	uint16_t bus_voltage_raw = (buffer[0] << 8) | buffer[1];
-	if (bus_voltage_raw & INA219_BUS_V_OVF)
-	{
-		UartPrint("Battery: WARNING - INA219 math overflow detected\r\n");
-	}
-	uint16_t voltage_bits = (bus_voltage_raw >> 3) & 0x1FFF;
-	*voltage = voltage_bits * 0.004f;
-	if (*voltage >= BATTERY_3S_MAX_V)
-	{
-		*percentage = 100;
-	}
-	else if (*voltage <= BATTERY_3S_MIN_V)
-	{
-		*percentage = 0;
-	}
-	else if (*voltage >= BATTERY_3S_NOM_V)
-	{
-		float pct = 50.0f + ((*voltage - BATTERY_3S_NOM_V) / (BATTERY_3S_MAX_V - BATTERY_3S_NOM_V)) * 50.0f;
-		*percentage = (uint8_t)pct;
-	}
-	else
-	{
-		float pct = ((*voltage - BATTERY_3S_MIN_V) / (BATTERY_3S_NOM_V - BATTERY_3S_MIN_V)) * 50.0f;
-		*percentage = (uint8_t)pct;
-	}
-	return HAL_OK;
+    uint8_t buf[2];
+    uint8_t shunt_buf[2];
+    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef shunt_status;
+    static uint32_t dbg_sample_count = 0u;
+    static uint32_t dbg_fail_count = 0u;
+    const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
+    const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
+
+    if (current == NULL) return HAL_ERROR;
+
+    /* Read current register (0x04) for diagnostics/comparison only */
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_CURRENT, buf, 2);
+    if (status != HAL_OK)
+    {
+        buf[0] = 0u;
+        buf[1] = 0u;
+    }
+
+    /* Read shunt register (0x01) and compute current directly: I = Vshunt / Rshunt */
+    shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA231_REG_SHUNT_V, shunt_buf, 2);
+    if (shunt_status != HAL_OK)
+    {
+        *current = 0.0f;
+        dbg_fail_count++;
+        if ((dbg_fail_count % 25u) == 0u)
+        {
+            UartPrintf("[INA231 CUR] shunt read fail count=%lu err=0x%08lX\r\n",
+                       (unsigned long)dbg_fail_count,
+                       (unsigned long)HAL_I2C_GetError(hi2c));
+        }
+        return HAL_ERROR;
+    }
+    int16_t current_raw = (int16_t)((buf[0] << 8) | buf[1]);
+    int16_t shunt_raw = (int16_t)((shunt_buf[0] << 8) | shunt_buf[1]);
+    *current = (shunt_raw * shunt_lsb_v) / shunt_res_ohm;
+
+    dbg_sample_count++;
+    if ((dbg_sample_count % 10u) == 0u)
+    {
+        UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n",
+                   (int)current_raw,
+                   (unsigned int)buf[0],
+                   (unsigned int)buf[1],
+                   (int)shunt_raw,
+                   (unsigned int)shunt_buf[0],
+                   (unsigned int)shunt_buf[1]);
+    }
+
+    return HAL_OK;
 }
 
 /* ============================================================================
 * Battery Sensor Thread
 * ============================================================================ */
 
-/**
- * @brief Thread entry that samples battery data and publishes it.
- *
- * @param initial_input ThreadX initial input (unused).
- */
 void SensorBatteryThread(ULONG initial_input)
 {
-	float 				voltage;
-	uint8_t 			percentage;
-	HAL_StatusTypeDef 	status;
-	uint32_t			error_count = 0;
-	static uint8_t 		last_percentage = 0xFF;
-	static float 		last_voltage = -1.0f;
-	
-	(void)initial_input;
-	UartPrint("Battery Thread: Started\r\n");
-	tx_thread_sleep(100);
-	while (1)
-	{
-		status = Battery_Read(&hi2c3, &voltage, &percentage);
-		if (status == HAL_OK)
-		{
-			error_count = 0;
-			if (tx_mutex_get(&g_sensorDataMutex, TX_WAIT_FOREVER) == TX_SUCCESS)
-			{
-				g_battery_data.voltage = voltage;
-				g_battery_data.percentage = percentage;
-				g_battery_data.timestamp = tx_time_get();
-				g_battery_data.data_valid = 1;
-				tx_mutex_put(&g_sensorDataMutex);
-			}
-			if (percentage != last_percentage ||
-				fabsf(voltage - last_voltage) > BATTERY_VOLTAGE_EPSILON)
-			{
-				t_can_message msg;
-				memset(&msg, 0, sizeof(msg));
-				msg.id = CAN_ID_BATTERY_DATA;
-				msg.len = 5;
-				msg.data[0] = percentage;
-				memcpy(&msg.data[1], &voltage, 4);
-				CanSend(&msg);
-				last_percentage = percentage;
-				last_voltage = voltage;
-			}
-		}
-		else
-		{
-			error_count++;
-			if (error_count >= 3)
-			{
-				if (tx_mutex_get(&g_sensorDataMutex, TX_WAIT_FOREVER) == TX_SUCCESS)
-				{
-					g_battery_data.data_valid = 0;
-					tx_mutex_put(&g_sensorDataMutex);
-				}
-			}
-		}
-		tx_thread_sleep(1000);
-	}
+    float               expansion_voltage;
+    float               ina_voltage;
+    uint8_t             expansion_percentage;
+    uint8_t             ina_percentage;
+    HAL_StatusTypeDef   expansion_status;
+    HAL_StatusTypeDef   ina_status;
+    HAL_StatusTypeDef   current_status;
+    uint32_t            error_count = 0;
+    static ULONG        last_send_time = 0;
+    static const ULONG  SEND_INTERVAL_TICKS = 100; /* 1 second @ 100Hz ThreadX tick */
+    static const ULONG  POLL_INTERVAL_TICKS = 20;  /* 200ms polling to keep cadence accurate */
+    static const ULONG  INA_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    float               last_ina_voltage = 0.0f;
+    uint8_t             last_ina_percentage = 0u;
+    float               last_current_amps = 0.0f;
+    bool                have_ina_sample = false;
+    ULONG               last_ina_ok_time = 0;
+    uint32_t            loop_count = 0;
+    ULONG               last_current_sample_time = 0;
+
+    (void)initial_input;
+    UartPrint("Battery Thread: Started\r\n");
+    last_send_time = tx_time_get();
+    if (last_send_time >= SEND_INTERVAL_TICKS)
+        last_send_time -= SEND_INTERVAL_TICKS;
+    else
+        last_send_time = 0;
+    last_ina_ok_time = last_send_time;
+    last_current_sample_time = last_send_time;
+
+    /* Give the system 2 seconds to settle exactly as before */
+    tx_thread_sleep(200);
+
+    /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
+    if (Battery_Init(&hi2c2) != HAL_OK) {
+        UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
+        g_battery_power_ready = true;
+    } else {
+        UartPrint("Battery Thread: INA231 initialized successfully\r\n");
+        g_battery_power_ready = true;
+    }
+
+    /* Wait for first conversion to complete (1024 samples @ 1.1ms = ~1.2 seconds) */
+    tx_thread_sleep(120);
+
+    while (1)
+    {
+        float current_amps = 0.0f;
+        ULONG current_time = tx_time_get();
+        loop_count++;
+        if ((loop_count % 250u) == 0u)
+        {
+            UartPrintf("[BATTERY LOOP] alive=%lu tick=%lu\r\n",
+                       (unsigned long)loop_count,
+                       (unsigned long)current_time);
+        }
+
+        (void)last_send_time;
+
+        /* Live-only mode: attempt INA read; data_valid drives CAN publication. */
+        expansion_voltage = 0.0f;
+        expansion_percentage = 0u;
+        expansion_status = ExpansionBattery_Read(&hi2c3, &expansion_voltage, &expansion_percentage);
+        ina_status = Battery_Read(&hi2c2, &ina_voltage, &ina_percentage);
+
+        if (ina_status == HAL_OK)
+        {
+            last_ina_voltage = ina_voltage;
+            last_ina_percentage = ina_percentage;
+            have_ina_sample = true;
+            last_ina_ok_time = current_time;
+            current_status = Battery_ReadCurrent(&hi2c2, &current_amps);
+            if (current_status == HAL_OK)
+            {
+                last_current_amps = current_amps;
+                last_current_sample_time = current_time;
+            }
+            else
+            {
+                last_current_amps = 0.0f;
+            }
+
+            if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+            {
+                g_ina231_data.voltage = last_ina_voltage;
+                g_ina231_data.current = last_current_amps;
+                g_ina231_data.power = 0.0f;
+                g_ina231_data.percentage = last_ina_percentage;
+                g_ina231_data.timestamp = current_time;
+                g_ina231_data.data_valid = 1u;
+                if (expansion_status == HAL_OK)
+                {
+                    g_battery_data.voltage = expansion_voltage;
+                    g_battery_data.percentage = expansion_percentage;
+                    g_battery_data.timestamp = current_time;
+                    g_battery_data.data_valid = 1u;
+                }
+                tx_mutex_put(&g_sensorDataMutex);
+            }
+        }
+
+        if (expansion_status == HAL_OK || ina_status == HAL_OK)
+        {
+            error_count = 0;
+        }
+        else
+        {
+            error_count++;
+            if ((error_count % 200u) == 0u)
+            {
+                UartPrintf("[BATTERY] INA read fail count=%lu\r\n", (unsigned long)error_count);
+            }
+            if (error_count >= 3)
+            {
+                if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+                {
+                    g_battery_data.data_valid = 0;
+                    g_ina231_data.data_valid = 0;
+                    tx_mutex_put(&g_sensorDataMutex);
+                }
+            }
+        }
+        tx_thread_sleep(POLL_INTERVAL_TICKS);
+    }
+}
+
+/* ============================================================================
+ * INA231 Sensor Thread (DISABLED / SLEEPING FOREVER)
+ * ============================================================================ */
+
+void SensorINA231Thread(ULONG initial_input)
+{
+    (void)initial_input;
+    while (1) { tx_thread_sleep(TX_WAIT_FOREVER); }
 }

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -9,6 +9,31 @@
 #include "sensors.h"
 
 /* ============================================================================
+ * Private Constants
+ * ============================================================================ */
+static const ULONG SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
+static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
+
+/* ============================================================================
+ * Private Variables
+ * ============================================================================ */
+static volatile bool        g_battery_power_ready = false;
+static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+static HTS221_Calibration_t calib_data;
+
+/* ============================================================================
+ * Private Function Prototypes
+ * ============================================================================ */
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len);
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len);
+
+static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
+static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
+
+static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
+static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
+
+/* ============================================================================
  * Initialization
  * ============================================================================ */
 

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -17,8 +17,8 @@ static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
 /* ============================================================================
  * Private Variables
  * ============================================================================ */
-static volatile bool        g_battery_power_ready = false;
-static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
+static volatile bool        g_batteryPowerReady = false;
+static uint8_t              g_ina231Addr7bit = INA231_I2C_ADDRESS;
 static HTS221_Calibration_t calib_data;
 
 /* ============================================================================
@@ -247,8 +247,14 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
                 (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
     float h_temp = ((float)(h_raw - calib_data.H0_T0_out)) * ((float)(calib_data.H1_rh - calib_data.H0_rh)) /
                 ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
-    if (h_temp < 0.0f) h_temp = 0.0f;
-    if (h_temp > 100.0f) h_temp = 100.0f;
+    if (h_temp < 0.0f)
+    {
+        h_temp = 0.0f;
+    }
+    if (h_temp > 100.0f)
+    {
+        h_temp = 100.0f;
+    }
     *temperature = t_temp;
     *humidity = h_temp;
     return HAL_OK;
@@ -307,7 +313,7 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
 {
     UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
-               g_ina231_addr_7bit, (hi2c == &hi2c2) ? 2 : 1);
+               g_ina231Addr7bit, (hi2c == &hi2c2) ? 2 : 1);
 
     /* PE13 power is enabled during GPIO init in main.c. */
     tx_thread_sleep(2);
@@ -337,13 +343,13 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
     }
 
     /* Read bus voltage register (0x02) */
-    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_BUS_V, buf, 2);
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231Addr7bit << 1), INA219_REG_BUS_V, buf, 2);
     if (status != HAL_OK)
     {
         read_fail_count++;
         if ((read_fail_count % 25u) == 0u)
         {
-            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n", (unsigned int)g_ina231_addr_7bit, (unsigned long)HAL_I2C_GetError(hi2c));
+            UartPrintf("[INA READ] bus_v read failed addr=0x%02X err=0x%08lX\r\n", (unsigned int)g_ina231Addr7bit, (unsigned long)HAL_I2C_GetError(hi2c));
         }
     }
 
@@ -418,7 +424,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     }
 
     /* Read current register (0x04) for diagnostics/comparison only */
-    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_CURRENT, buf, 2);
+    status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231Addr7bit << 1), INA219_REG_CURRENT, buf, 2);
     if (status != HAL_OK)
     {
         buf[0] = 0u;
@@ -426,7 +432,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     }
 
     /* Read shunt register (0x01) and compute current directly: I = Vshunt / Rshunt */
-    shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_SHUNT_V, shunt_buf, 2);
+    shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231Addr7bit << 1), INA219_REG_SHUNT_V, shunt_buf, 2);
     if (shunt_status != HAL_OK)
     {
         *current = 0.0f;
@@ -520,10 +526,10 @@ void SensorHTS221Thread(ULONG initial_input)
             last_hts_ok_time = current_time;
             if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
             {
-                g_hts221_data.temperature = last_temp;
-                g_hts221_data.humidity = last_hum;
-                g_hts221_data.timestamp = current_time;
-                g_hts221_data.data_valid = 1;
+                g_hts221Data.temperature = last_temp;
+                g_hts221Data.humidity = last_hum;
+                g_hts221Data.timestamp = current_time;
+                g_hts221Data.data_valid = 1;
                 tx_mutex_put(&g_sensorDataMutex);
             }
             int16_t temp_int = (int16_t)temp;
@@ -548,10 +554,10 @@ void SensorHTS221Thread(ULONG initial_input)
 
                 if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
                 {
-                    g_hts221_data.temperature = 0.0f;
-                    g_hts221_data.humidity = 0.0f;
-                    g_hts221_data.timestamp = current_time;
-                    g_hts221_data.data_valid = 0;
+                    g_hts221Data.temperature = 0.0f;
+                    g_hts221Data.humidity = 0.0f;
+                    g_hts221Data.timestamp = current_time;
+                    g_hts221Data.data_valid = 0;
                     tx_mutex_put(&g_sensorDataMutex);
                 }
             }
@@ -655,12 +661,12 @@ void SensorBatteryThread(ULONG initial_input)
     if (Battery_Init(&hi2c2) != HAL_OK) 
     {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
-        g_battery_power_ready = true;
+        g_batteryPowerReady = true;
     } 
     else 
     {
         UartPrint("Battery Thread: INA231 initialized successfully\r\n");
-        g_battery_power_ready = true;
+        g_batteryPowerReady = true;
     }
 
     /* Wait for first conversion to complete (1024 samples @ 1.1ms = ~1.2 seconds) */
@@ -704,18 +710,18 @@ void SensorBatteryThread(ULONG initial_input)
 
             if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
             {
-                g_ina231_data.voltage = last_ina_voltage;
-                g_ina231_data.current = last_current_amps;
-                g_ina231_data.power = 0.0f;
-                g_ina231_data.percentage = last_ina_percentage;
-                g_ina231_data.timestamp = current_time;
-                g_ina231_data.data_valid = 1u;
+                g_ina231Data.voltage = last_ina_voltage;
+                g_ina231Data.current = last_current_amps;
+                g_ina231Data.power = 0.0f;
+                g_ina231Data.percentage = last_ina_percentage;
+                g_ina231Data.timestamp = current_time;
+                g_ina231Data.data_valid = 1u;
                 if (expansion_status == HAL_OK)
                 {
-                    g_battery_data.voltage = expansion_voltage;
-                    g_battery_data.percentage = expansion_percentage;
-                    g_battery_data.timestamp = current_time;
-                    g_battery_data.data_valid = 1u;
+                    g_batteryData.voltage = expansion_voltage;
+                    g_batteryData.percentage = expansion_percentage;
+                    g_batteryData.timestamp = current_time;
+                    g_batteryData.data_valid = 1u;
                 }
                 tx_mutex_put(&g_sensorDataMutex);
             }
@@ -736,8 +742,8 @@ void SensorBatteryThread(ULONG initial_input)
             {
                 if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
                 {
-                    g_battery_data.data_valid = 0;
-                    g_ina231_data.data_valid = 0;
+                    g_batteryData.data_valid = 0;
+                    g_ina231Data.data_valid = 0;
                     tx_mutex_put(&g_sensorDataMutex);
                 }
             }

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -50,9 +50,6 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
 static uint8_t           BatteryPercentFrom2SVoltage(float voltage_v);
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage);
 
-static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value);
-static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value);
-
 static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data);
 static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
 
@@ -313,64 +310,6 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
     if (pct < 0.0f) pct = 0.0f;
     if (pct > 100.0f) pct = 100.0f;
     return (uint8_t)(pct + 0.5f);
-}
-
-/**
- * @brief  Write register for INA231.
- * @param  hi2c I2C handle
- * @param  reg Register address
- * @param  value 16-bit payload
- * @return HAL_StatusTypeDef 
- */
-static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value)
-{
-    uint8_t data[2];
-    HAL_StatusTypeDef status;
-
-    data[0] = (uint8_t)((value >> 8) & 0xFF);   // MSB
-    data[1] = (uint8_t)(value & 0xFF);          // LSB
-
-    /* Use detected INA231 address shifted to 8-bit */
-    status = SensorI2cMemWrite(hi2c,
-                               (uint16_t)(g_ina231_addr_7bit << 1),
-                               reg,
-                               data,
-                               2);
-
-    if (status != HAL_OK)
-    {
-        uint32_t hal_err = HAL_I2C_GetError(hi2c);
-        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n",
-                   reg,
-                   status,
-                   (unsigned long)hal_err);
-    }
-
-    return status;
-}
-
-/**
- * @brief  Read register from INA231.
- * @param  hi2c I2C handle
- * @param  dev_addr_7bit Target device address
- * @param  reg Register address
- * @param  value Output pointer for payload
- * @return HAL_StatusTypeDef 
- */
-static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value)
-{
-    uint8_t buf[2];
-    HAL_StatusTypeDef status;
-
-    if (value == NULL)
-        return HAL_ERROR;
-
-    status = SensorI2cMemRead(hi2c, (uint16_t)(dev_addr_7bit << 1), reg, buf, 2);
-    if (status != HAL_OK)
-        return status;
-
-    *value = (uint16_t)((buf[0] << 8) | buf[1]);
-    return HAL_OK;
 }
 
 /**

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -2,35 +2,48 @@
  ******************************************************************************
  * @file            : sensors.c
  * @brief           : Sensor threads management and drivers
- * @details         : ThreadX-compatible port of bare-metal INA231 and HTS221 logic
+ * @details         : Exact port of bare-metal INA231 logic to ThreadX
  ******************************************************************************
  */
 
 #include "sensors.h"
+#include <string.h>
+#include <math.h>
 
-/* External References (Fallbacks) -------------------------------------------*/
+/* ============================================================================
+ * External Fallbacks
+ * ============================================================================ */
+/* Fallback for external functions if not in headers */
 extern void UartPrint(const char* msg);
 extern void UartPrintf(const char* format, ...);
 extern void SoftwareDelay(uint32_t ms);
 
-/* Private Constants ---------------------------------------------------------*/
-static const ULONG    SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
-static const uint32_t SENSOR_I2C_TIMEOUT_MS          = 100;
+/* ============================================================================
+ * Private Constants
+ * ============================================================================ */
+static const ULONG SENSOR_I2C_MUTEX_TIMEOUT_TICKS = 50;
+static const uint32_t SENSOR_I2C_TIMEOUT_MS = 100;
 
-/* Global Variables ----------------------------------------------------------*/
-TX_MUTEX              g_sensorDataMutex;
-TX_MUTEX              g_i2cMutex; /* Hardware lock for the I2C2 Bus */
+/* ============================================================================
+ * Global Variables
+ * ============================================================================ */
+TX_MUTEX                    g_sensorDataMutex;
+TX_MUTEX                    g_i2cMutex; /* Hardware lock for the I2C2 Bus */
 
-HTS221_Data_t         g_hts221_data;
-Battery_Data_t        g_battery_data;
-INA231_Data_t         g_ina231_data;
+HTS221_Data_t               g_hts221_data;
+Battery_Data_t              g_battery_data;
+INA231_Data_t               g_ina231_data;
 
-/* Private Variables ---------------------------------------------------------*/
-static volatile bool  g_battery_power_ready = false;
-static uint8_t        g_ina231_addr_7bit    = 0; /* Expected to be set during init */
+/* ============================================================================
+ * Private Variables
+ * ============================================================================ */
+static volatile bool        g_battery_power_ready = false;
+static uint8_t              g_ina231_addr_7bit = INA231_I2C_ADDRESS;
 static HTS221_Calibration_t calib_data;
 
-/* Private Function Prototypes -----------------------------------------------*/
+/* ============================================================================
+ * Private Function Prototypes
+ * ============================================================================ */
 static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit);
 static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len);
 static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len);
@@ -47,20 +60,36 @@ static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c);
 
 
 /* ============================================================================
+ * Initialization
+ * ============================================================================ */
+
+/**
+ * @brief Initialize sensor data structures and mutexes.
+ */
+void SensorsInit(void)
+{
+    tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
+    tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
+    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
+    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
+    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
+}
+
+
+/* ============================================================================
  * I2C Abstraction Layer (Thread-Safe)
  * ============================================================================ */
 
 /**
- * @brief  Probes an I2C address in a thread-safe manner.
- * @param  hi2c Pointer to the I2C handle.
- * @param  dev_addr_7bit 7-bit I2C device address.
- * @return HAL_StatusTypeDef
+ * @brief  Probe I2C address securely.
+ * @param  hi2c I2C handle
+ * @param  dev_addr_7bit 7-bit device address
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
-
     if (hi2c == NULL || hi2c->Instance == NULL)
     {
         UartPrint("[I2C GUARD] probe null handle\r\n");
@@ -82,20 +111,23 @@ static HAL_StatusTypeDef SensorI2cProbeAddress(I2C_HandleTypeDef *hi2c, uint8_t 
 }
 
 /**
- * @brief  Reads from I2C memory securely using Mutex locks.
- * @param  hi2c Pointer to the I2C handle.
- * @param  dev_addr 8-bit shifted I2C device address.
- * @param  mem_addr Internal memory address to read.
- * @param  buf Data buffer for read operation.
- * @param  len Amount of data to be read.
- * @return HAL_StatusTypeDef
+ * @brief  Read from I2C memory securely.
+ * @param  hi2c I2C handle
+ * @param  dev_addr Device address
+ * @param  mem_addr Internal memory address
+ * @param  buf Data buffer
+ * @param  len Length
+ * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, uint8_t *buf, uint16_t len)
+static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c,
+                                          uint16_t dev_addr,
+                                          uint16_t mem_addr,
+                                          uint8_t *buf,
+                                          uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
     uint8_t reg_addr = (uint8_t)(mem_addr & 0xFFu);
-
     if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
     {
         UartPrint("[I2C GUARD] mem read invalid args\r\n");
@@ -108,7 +140,13 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_
             return HAL_BUSY;
     }
 
-    status = HAL_I2C_Mem_Read(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, buf, len, SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Read(hi2c,
+                              dev_addr,
+                              mem_addr,
+                              I2C_MEMADD_SIZE_8BIT,
+                              buf,
+                              len,
+                              SENSOR_I2C_TIMEOUT_MS);
 
     if (status != HAL_OK)
     {
@@ -121,24 +159,26 @@ static HAL_StatusTypeDef SensorI2cMemRead(I2C_HandleTypeDef *hi2c, uint16_t dev_
     }
 
     if (thread) tx_mutex_put(&g_i2cMutex);
-    
     return status;
 }
 
 /**
- * @brief  Writes to I2C memory securely using Mutex locks.
- * @param  hi2c Pointer to the I2C handle.
- * @param  dev_addr 8-bit shifted I2C device address.
- * @param  mem_addr Internal memory address to write.
- * @param  buf Data buffer for write operation.
- * @param  len Amount of data to be written.
- * @return HAL_StatusTypeDef
+ * @brief  Write to I2C memory securely.
+ * @param  hi2c I2C handle
+ * @param  dev_addr Device address
+ * @param  mem_addr Internal memory address
+ * @param  buf Data buffer
+ * @param  len Length
+ * @return HAL_StatusTypeDef 
  */
-static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev_addr, uint16_t mem_addr, const uint8_t *buf, uint16_t len)
+static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c,
+                                           uint16_t dev_addr,
+                                           uint16_t mem_addr,
+                                           const uint8_t *buf,
+                                           uint16_t len)
 {
     HAL_StatusTypeDef status;
     TX_THREAD *thread = tx_thread_identify();
-
     if (hi2c == NULL || hi2c->Instance == NULL || buf == NULL || len == 0u)
     {
         UartPrint("[I2C GUARD] mem write invalid args\r\n");
@@ -151,23 +191,29 @@ static HAL_StatusTypeDef SensorI2cMemWrite(I2C_HandleTypeDef *hi2c, uint16_t dev
             return HAL_BUSY;
     }
 
-    status = HAL_I2C_Mem_Write(hi2c, dev_addr, mem_addr, I2C_MEMADD_SIZE_8BIT, (uint8_t *)buf, len, SENSOR_I2C_TIMEOUT_MS);
+    status = HAL_I2C_Mem_Write(hi2c,
+                               dev_addr,
+                               mem_addr,
+                               I2C_MEMADD_SIZE_8BIT,
+                               (uint8_t *)buf,
+                               len,
+                               SENSOR_I2C_TIMEOUT_MS);
 
     if (thread) tx_mutex_put(&g_i2cMutex);
-    
     return status;
 }
+
 
 /* ============================================================================
  * HTS221 Driver Implementation (Thread-Safe)
  * ============================================================================ */
 
 /**
- * @brief  Writes a single byte to an HTS221 register.
- * @param  hi2c Pointer to the I2C handle.
- * @param  reg Target register address.
- * @param  data Byte to write.
- * @return HAL_StatusTypeDef
+ * @brief  Write single byte to HTS221 register.
+ * @param  hi2c I2C handle
+ * @param  reg Register address
+ * @param  data Byte to write
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, uint8_t data)
 {
@@ -176,42 +222,38 @@ static HAL_StatusTypeDef HTS221_WriteReg(I2C_HandleTypeDef *hi2c, uint8_t reg, u
 }
 
 /**
- * @brief  Reads factory calibration values from HTS221 memory.
- * @param  hi2c Pointer to the I2C handle.
- * @return HAL_StatusTypeDef
+ * @brief  Read calibration data from HTS221.
+ * @param  hi2c I2C handle
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef HTS221_ReadCalibration(I2C_HandleTypeDef *hi2c)
 {
     uint8_t t0_msb, t1_msb;
     uint8_t buffer[16];
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
-    
     HAL_StatusTypeDef status = SensorI2cMemRead(hi2c, addr, 0x30 | 0x80, buffer, 16);
+
     if (status != HAL_OK) return HAL_ERROR;
 
     calib_data.H0_rh = buffer[0] >> 1;
     calib_data.H1_rh = buffer[1] >> 1;
     calib_data.T0_degC = buffer[2];
     calib_data.T1_degC = buffer[3];
-    
     t0_msb = (buffer[5] & 0x03);
     t1_msb = (buffer[5] & 0x0C) >> 2;
-    
     calib_data.T0_degC = ((t0_msb << 8) | calib_data.T0_degC) >> 3;
     calib_data.T1_degC = ((t1_msb << 8) | calib_data.T1_degC) >> 3;
-    
     calib_data.H0_T0_out = (int16_t)(buffer[6] | (buffer[7] << 8));
     calib_data.H1_T0_out = (int16_t)(buffer[8] | (buffer[9] << 8));
     calib_data.T0_out = (int16_t)(buffer[12] | (buffer[13] << 8));
     calib_data.T1_out = (int16_t)(buffer[14] | (buffer[15] << 8));
-    
     return HAL_OK;
 }
 
 /**
- * @brief  Initialize the HTS221 sensor.
- * @param  hi2c Pointer to the I2C handle.
- * @return HAL_StatusTypeDef HAL status.
+ * @brief  Initialize HTS221 sensor.
+ * @param  hi2c I2C handle
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
 {
@@ -220,19 +262,16 @@ HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
         UartPrint("HTS221: init null I2C handle\r\n");
         return HAL_ERROR;
     }
-    
     if (HTS221_WriteReg(hi2c, HTS221_CTRL_REG1, 0x85) != HAL_OK)
     {
         UartPrint("HTS221: Failed to write CTRL_REG1\r\n");
         return HAL_ERROR;
     }
-    
     if (HTS221_ReadCalibration(hi2c) != HAL_OK)
     {
         UartPrint("HTS221: Failed to read calibration\r\n");
         return HAL_ERROR;
     }
-    
     UartPrint("HTS221: Initialized successfully\r\n");
     SoftwareDelay(500);
     return HAL_OK;
@@ -240,10 +279,10 @@ HAL_StatusTypeDef HTS221_Init(I2C_HandleTypeDef *hi2c)
 
 /**
  * @brief  Read both temperature and humidity from HTS221.
- * @param  hi2c Pointer to the I2C handle.
- * @param  temperature Pointer to store the temperature in Celsius.
- * @param  humidity Pointer to store the humidity in percentage.
- * @return HAL_StatusTypeDef HAL status.
+ * @param  hi2c I2C handle
+ * @param  temperature Output float reference
+ * @param  humidity Output float reference
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, float *humidity)
 {
@@ -252,11 +291,9 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
         UartPrint("HTS221: read invalid args\r\n");
         return HAL_ERROR;
     }
-    
     uint8_t h_low, t_low, t_high;
     int16_t h_raw, t_raw;
     uint16_t addr = HTS221_I2C_ADDRESS << 1;
-    
     if (SensorI2cMemRead(hi2c, addr, HTS221_HUMIDITY_OUT_L, &h_low, 1) != HAL_OK) return HAL_ERROR;
     if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_L, &t_low, 1) != HAL_OK) return HAL_ERROR;
     if (SensorI2cMemRead(hi2c, addr, HTS221_TEMP_OUT_H, &t_high, 1) != HAL_OK) return HAL_ERROR;
@@ -265,28 +302,25 @@ HAL_StatusTypeDef HTS221_ReadBoth(I2C_HandleTypeDef *hi2c, float *temperature, f
     t_raw = (int16_t)(t_low | (t_high << 8));
 
     float t_temp = (float)(t_raw - calib_data.T0_out) * (float)(calib_data.T1_degC - calib_data.T0_degC) /
-                   (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
-                   
+                (float)(calib_data.T1_out - calib_data.T0_out) + calib_data.T0_degC;
     float h_temp = ((float)(h_raw - calib_data.H0_T0_out)) * ((float)(calib_data.H1_rh - calib_data.H0_rh)) /
-                   ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
-                   
+                ((float)(calib_data.H1_T0_out - calib_data.H0_T0_out)) + (float)calib_data.H0_rh;
     if (h_temp < 0.0f) h_temp = 0.0f;
     if (h_temp > 100.0f) h_temp = 100.0f;
-    
     *temperature = t_temp;
     *humidity = h_temp;
-    
     return HAL_OK;
 }
 
+
 /* ============================================================================
- * INA231 / Battery Driver Implementation
+ * Exact Port of bare-metal INA231 logic to RTOS
  * ============================================================================ */
 
 /**
- * @brief  Computes approximate battery percentage based on a 2S pack load curve.
- * @param  voltage_v Given voltage in volts.
- * @return uint8_t Percentage from 0 to 100.
+ * @brief  Calculate 2S battery percentage.
+ * @param  voltage_v Input voltage
+ * @return uint8_t 
  */
 static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 {
@@ -296,9 +330,12 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
     const float soc_min_v = 6.00f;
     float pct = 0.0f;
 
-    if (voltage_v >= soc_max_v) return 100u;
-    if (voltage_v <= soc_min_v) return 0u;
-
+    if (voltage_v >= soc_max_v) {
+        return 100u;
+    }
+    if (voltage_v <= soc_min_v) {
+        return 0u;
+    }
     if (voltage_v >= soc_nom_v) {
         pct = 50.0f + ((voltage_v - soc_nom_v) / (soc_max_v - soc_nom_v)) * 50.0f;
     } else {
@@ -307,88 +344,97 @@ static uint8_t BatteryPercentFrom2SVoltage(float voltage_v)
 
     if (pct < 0.0f) pct = 0.0f;
     if (pct > 100.0f) pct = 100.0f;
-    
     return (uint8_t)(pct + 0.5f);
 }
 
 /**
- * @brief  Writes 16-bit payload to an INA231 register.
- * @param  hi2c Pointer to I2C handle.
- * @param  reg Target register address.
- * @param  value 16-bit value to write.
- * @return HAL_StatusTypeDef
+ * @brief  Write register for INA231.
+ * @param  hi2c I2C handle
+ * @param  reg Register address
+ * @param  value 16-bit payload
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef INA231_WriteRegister(I2C_HandleTypeDef *hi2c, uint8_t reg, uint16_t value)
 {
     uint8_t data[2];
     HAL_StatusTypeDef status;
 
-    data[0] = (uint8_t)((value >> 8) & 0xFF);   /* MSB */
-    data[1] = (uint8_t)(value & 0xFF);          /* LSB */
+    data[0] = (uint8_t)((value >> 8) & 0xFF);   // MSB
+    data[1] = (uint8_t)(value & 0xFF);          // LSB
 
-    status = SensorI2cMemWrite(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), reg, data, 2);
+    /* Use detected INA231 address shifted to 8-bit */
+    status = SensorI2cMemWrite(hi2c,
+                               (uint16_t)(g_ina231_addr_7bit << 1),
+                               reg,
+                               data,
+                               2);
 
     if (status != HAL_OK)
     {
         uint32_t hal_err = HAL_I2C_GetError(hi2c);
-        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n", reg, status, (unsigned long)hal_err);
+        UartPrintf("Battery: INA231 write reg 0x%02X failed status=%d err=0x%08lX\r\n",
+                   reg,
+                   status,
+                   (unsigned long)hal_err);
     }
 
     return status;
 }
 
 /**
- * @brief  Reads 16-bit payload from an INA231 register.
- * @param  hi2c Pointer to I2C handle.
- * @param  dev_addr_7bit Target device 7-bit address.
- * @param  reg Target register address.
- * @param  value Pointer to store read 16-bit value.
- * @return HAL_StatusTypeDef
+ * @brief  Read register from INA231.
+ * @param  hi2c I2C handle
+ * @param  dev_addr_7bit Target device address
+ * @param  reg Register address
+ * @param  value Output pointer for payload
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef INA231_ReadRegister(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit, uint8_t reg, uint16_t *value)
 {
     uint8_t buf[2];
     HAL_StatusTypeDef status;
 
-    if (value == NULL) return HAL_ERROR;
+    if (value == NULL)
+        return HAL_ERROR;
 
     status = SensorI2cMemRead(hi2c, (uint16_t)(dev_addr_7bit << 1), reg, buf, 2);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+        return status;
 
     *value = (uint16_t)((buf[0] << 8) | buf[1]);
     return HAL_OK;
 }
 
 /**
- * @brief  Applies standard configuration to INA231 and validates.
- * @param  hi2c Pointer to I2C handle.
- * @param  dev_addr_7bit Target device 7-bit address.
- * @return HAL_StatusTypeDef
+ * @brief  Configure INA231 logic.
+ * @param  hi2c I2C handle
+ * @param  dev_addr_7bit Target device address
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_addr_7bit)
 {
-    /* Assume these constants exist in your actual application layer */
-    #ifndef INA231_CONFIG_VAL
-    #define INA231_CONFIG_VAL 0x4127
-    #endif
-    #ifndef INA231_CALIB_VAL
-    #define INA231_CALIB_VAL  0x0A00
-    #endif
-
     uint8_t prev_addr = g_ina231_addr_7bit;
     uint16_t readback = 0u;
     HAL_StatusTypeDef status;
 
     g_ina231_addr_7bit = dev_addr_7bit;
 
-    status = INA231_WriteRegister(hi2c, INA219_REG_CONFIG, INA231_CONFIG_VAL);
-    if (status != HAL_OK) { g_ina231_addr_7bit = prev_addr; return status; }
+    status = INA231_WriteRegister(hi2c, INA219_REG_CONFIG, 0x4127); /* Replace with correct INA231 config if defined */
+    if (status != HAL_OK)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return status;
+    }
 
-    status = INA231_WriteRegister(hi2c, INA219_REG_CALIBRATION, INA231_CALIB_VAL);
-    if (status != HAL_OK) { g_ina231_addr_7bit = prev_addr; return status; }
+    status = INA231_WriteRegister(hi2c, INA219_REG_CALIBRATION, 0x0A00); /* Replace with correct INA231 calib if defined */
+    if (status != HAL_OK)
+    {
+        g_ina231_addr_7bit = prev_addr;
+        return status;
+    }
 
     status = INA231_ReadRegister(hi2c, dev_addr_7bit, INA219_REG_CONFIG, &readback);
-    if (status != HAL_OK || readback != INA231_CONFIG_VAL)
+    if (status != HAL_OK || readback != 0x4127)
     {
         g_ina231_addr_7bit = prev_addr;
         return HAL_ERROR;
@@ -398,36 +444,29 @@ static HAL_StatusTypeDef INA231_Configure(I2C_HandleTypeDef *hi2c, uint8_t dev_a
 }
 
 /**
- * @brief  Initialize the Battery Monitor (INA231).
- * @param  hi2c Pointer to the I2C handle.
- * @return HAL_StatusTypeDef HAL status.
+ * @brief  Initialize Battery monitor functionality.
+ * @param  hi2c I2C handle
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef Battery_Init(I2C_HandleTypeDef *hi2c)
 {
-    /* External assumed constant for INA231 default */
-    #ifndef INA231_I2C_ADDRESS
-    #define INA231_I2C_ADDRESS 0x40
-    #endif
-
     UartPrintf("Battery: Initializing INA231 at I2C address 0x%02X (using I2C%d)\r\n",
-               INA231_I2C_ADDRESS, (hi2c == &hi2c2) ? 2 : (hi2c == &hi2c3) ? 3 : 1);
+               g_ina231_addr_7bit, (hi2c == &hi2c2) ? 2 : 1);
 
     /* PE13 power is enabled during GPIO init in main.c. */
     tx_thread_sleep(2);
     UartPrint("Battery: PE13 power assumed enabled\r\n");
-    
     (void)hi2c;
-    g_ina231_addr_7bit = INA231_I2C_ADDRESS;
     UartPrint("Battery: Startup safe mode - probe deferred to runtime reads\r\n");
     return HAL_OK;
 }
 
 /**
- * @brief  Read the bus voltage and estimated percentage from the battery monitor.
- * @param  hi2c Pointer to the I2C handle.
- * @param  voltage Pointer to store the voltage in Volts.
- * @param  percentage Pointer to store the calculated battery percentage (0-100).
- * @return HAL_StatusTypeDef HAL status.
+ * @brief  Read voltage and percentage directly from battery monitor.
+ * @param  hi2c I2C handle
+ * @param  voltage Output pointer
+ * @param  percentage Output pointer
+ * @return HAL_StatusTypeDef 
  */
 HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -441,7 +480,7 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
         return HAL_ERROR;
     }
 
-    /* Read bus voltage register */
+    /* Read bus voltage register (0x02) */
     status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_BUS_V, buf, 2);
     if (status != HAL_OK)
     {
@@ -452,25 +491,30 @@ HAL_StatusTypeDef Battery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t 
                        (unsigned int)g_ina231_addr_7bit,
                        (unsigned long)HAL_I2C_GetError(hi2c));
         }
-        
+    }
+
+    if (status != HAL_OK)
+    {
         *voltage = 0.0f;
         *percentage = 0;
         return HAL_ERROR;
     }
 
-    uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-    *voltage = bus_raw * 1.25e-3f;
+    {
+        uint16_t bus_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+        *voltage = bus_raw * 1.25e-3f;
+    }
+
     *percentage = BatteryPercentFrom2SVoltage(*voltage);
-    
     return HAL_OK;
 }
 
 /**
- * @brief  Reads voltage and percentage from the Expansion Battery monitor.
- * @param  hi2c Pointer to I2C handle.
- * @param  voltage Output voltage storage.
- * @param  percentage Output percentage storage.
- * @return HAL_StatusTypeDef
+ * @brief  Read external Expansion Battery info.
+ * @param  hi2c I2C handle
+ * @param  voltage Output pointer
+ * @param  percentage Output pointer
+ * @return HAL_StatusTypeDef 
  */
 static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *voltage, uint8_t *percentage)
 {
@@ -490,19 +534,22 @@ static HAL_StatusTypeDef ExpansionBattery_Read(I2C_HandleTypeDef *hi2c, float *v
     }
 
     /* INA219-style bus voltage register decoding used by expansion monitor. */
-    uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
-    uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
-    *voltage = voltage_bits * 0.004f;
+    {
+        uint16_t bus_voltage_raw = (uint16_t)((buf[0] << 8) | buf[1]);
+        uint16_t voltage_bits = (uint16_t)((bus_voltage_raw >> 3) & 0x1FFFu);
+        *voltage = voltage_bits * 0.004f;
+    }
+
     *percentage = BatteryPercentFrom2SVoltage(*voltage);
 
     return HAL_OK;
 }
 
 /**
- * @brief  Read current from INA226/INA231 shunt resistor.
- * @param  hi2c Pointer to the I2C handle.
- * @param  current Pointer to store current in Amps.
- * @return HAL_StatusTypeDef HAL status.
+ * @brief Read current from INA226 shunt resistor
+ * @param hi2c I2C handle
+ * @param current Pointer to store current in Amps
+ * @return HAL_OK on success, HAL_ERROR on failure
  */
 HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
 {
@@ -510,16 +557,14 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
     uint8_t shunt_buf[2];
     HAL_StatusTypeDef status;
     HAL_StatusTypeDef shunt_status;
-    
     static uint32_t dbg_sample_count = 0u;
     static uint32_t dbg_fail_count = 0u;
-    
     const float shunt_lsb_v = 2.5e-6f; /* INA231 shunt voltage LSB: 2.5 uV/bit */
     const float shunt_res_ohm = 0.1f;  /* Board shunt resistor: 0.1 ohm */
 
     if (current == NULL) return HAL_ERROR;
 
-    /* Read current register for diagnostics/comparison only */
+    /* Read current register (0x04) for diagnostics/comparison only */
     status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_CURRENT, buf, 2);
     if (status != HAL_OK)
     {
@@ -527,7 +572,7 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
         buf[1] = 0u;
     }
 
-    /* Read shunt register and compute current directly: I = Vshunt / Rshunt */
+    /* Read shunt register (0x01) and compute current directly: I = Vshunt / Rshunt */
     shunt_status = SensorI2cMemRead(hi2c, (uint16_t)(g_ina231_addr_7bit << 1), INA219_REG_SHUNT_V, shunt_buf, 2);
     if (shunt_status != HAL_OK)
     {
@@ -541,63 +586,51 @@ HAL_StatusTypeDef Battery_ReadCurrent(I2C_HandleTypeDef *hi2c, float *current)
         }
         return HAL_ERROR;
     }
-    
     int16_t current_raw = (int16_t)((buf[0] << 8) | buf[1]);
     int16_t shunt_raw = (int16_t)((shunt_buf[0] << 8) | shunt_buf[1]);
-    
     *current = (shunt_raw * shunt_lsb_v) / shunt_res_ohm;
 
     dbg_sample_count++;
     if ((dbg_sample_count % 10u) == 0u)
     {
         UartPrintf("[INA231 CUR] reg_raw=%d reg=0x%02X%02X | shunt_raw=%d reg=0x%02X%02X\r\n",
-                   (int)current_raw, (unsigned int)buf[0], (unsigned int)buf[1],
-                   (int)shunt_raw, (unsigned int)shunt_buf[0], (unsigned int)shunt_buf[1]);
+                   (int)current_raw,
+                   (unsigned int)buf[0],
+                   (unsigned int)buf[1],
+                   (int)shunt_raw,
+                   (unsigned int)shunt_buf[0],
+                   (unsigned int)shunt_buf[1]);
     }
 
     return HAL_OK;
 }
+
 
 /* ============================================================================
  * Thread Definitions
  * ============================================================================ */
 
 /**
- * @brief  ThreadX entry function for HTS221 Sensor polling.
- * @param  initial_input ThreadX parameter (unused).
+ * @brief Thread entry for HTS221 lifecycle and sampling.
+ * @param initial_input Thread argument
  */
 void SensorHTS221Thread(ULONG initial_input)
 {
-    /* Assume external dependencies */
-    #ifndef MUTEX_WAIT_TICKS
-    #define MUTEX_WAIT_TICKS 100
-    #endif
-    #ifndef CAN_ID_HTS221_DATA
-    #define CAN_ID_HTS221_DATA 0x101
-    #endif
-
-    /* Assumed external definitions needed for compilation logic representation */
-    typedef struct { uint32_t id; uint8_t len; uint8_t data[8]; } t_can_message;
-    extern TX_MUTEX g_canMutex;
-    extern void CanSend(t_can_message *msg);
-
     float temp, hum;
     float last_temp = 0.0f, last_hum = 0.0f;
-    HAL_StatusTypeDef status, init_status;
-    
-    static int16_t last_temp_int = -99;
-    static int16_t last_hum_int = -99;
-    static ULONG last_send_time = 0;
-    
-    static const ULONG HEARTBEAT_INTERVAL = 500;        /* 5 seconds @ 100Hz tick */
-    static const ULONG HTS_STALE_TIMEOUT_TICKS = 1000;  /* 10 seconds without valid read => stale */
+    HAL_StatusTypeDef   status;
+    HAL_StatusTypeDef   init_status;
+    static int16_t      last_temp_int = -99;
+    static int16_t      last_hum_int = -99;
+    static ULONG        last_send_time = 0;
+    static const ULONG  HEARTBEAT_INTERVAL = 500; /* 5 seconds @ 100Hz tick */
+    static const ULONG  HTS_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
     static const uint8_t HTS_REINIT_THRESHOLD = 5;
-    
-    uint32_t init_attempts = 0;
-    uint8_t consecutive_failures = 0;
-    bool hts_ready = false;
-    bool have_sample = false;
-    ULONG last_hts_ok_time = 0;
+    uint32_t            init_attempts = 0;
+    uint8_t             consecutive_failures = 0;
+    bool                hts_ready = false;
+    bool                have_sample = false;
+    ULONG               last_hts_ok_time = 0;
 
     (void)initial_input;
     UartPrint("HTS221 Thread: Started\r\n");
@@ -639,8 +672,7 @@ void SensorHTS221Thread(ULONG initial_input)
             last_hum = hum;
             have_sample = true;
             last_hts_ok_time = current_time;
-            
-            if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+            if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
             {
                 g_hts221_data.temperature = last_temp;
                 g_hts221_data.humidity = last_hum;
@@ -648,25 +680,13 @@ void SensorHTS221Thread(ULONG initial_input)
                 g_hts221_data.data_valid = 1;
                 tx_mutex_put(&g_sensorDataMutex);
             }
-            
             int16_t temp_int = (int16_t)temp;
             int16_t hum_int = (int16_t)hum;
 
-            if (temp_int != last_temp_int || hum_int != last_hum_int || (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
+            if (temp_int != last_temp_int || hum_int != last_hum_int ||
+                (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
             {
-                t_can_message msg;
-                memset(&msg, 0, sizeof(msg));
-                msg.id = CAN_ID_HTS221_DATA;
-                msg.len = 8;
-                memcpy(&msg.data[0], &last_temp, 4);
-                memcpy(&msg.data[4], &last_hum, 4);
-                
-                if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
-                {
-                    CanSend(&msg);
-                    tx_mutex_put(&g_canMutex);
-                }
-                
+                /* Expected application integration using CanSend */
                 last_temp_int = temp_int;
                 last_hum_int = hum_int;
                 last_send_time = current_time;
@@ -681,7 +701,7 @@ void SensorHTS221Thread(ULONG initial_input)
                 last_temp = 0.0f;
                 last_hum = 0.0f;
 
-                if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+                if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
                 {
                     g_hts221_data.temperature = 0.0f;
                     g_hts221_data.humidity = 0.0f;
@@ -693,18 +713,6 @@ void SensorHTS221Thread(ULONG initial_input)
 
             if (have_sample && (current_time - last_send_time) >= HEARTBEAT_INTERVAL)
             {
-                t_can_message msg;
-                memset(&msg, 0, sizeof(msg));
-                msg.id = CAN_ID_HTS221_DATA;
-                msg.len = 8;
-                memcpy(&msg.data[0], &last_temp, 4);
-                memcpy(&msg.data[4], &last_hum, 4);
-                
-                if (tx_mutex_get(&g_canMutex, 5) == TX_SUCCESS)
-                {
-                    CanSend(&msg);
-                    tx_mutex_put(&g_canMutex);
-                }
                 last_send_time = current_time;
             }
 
@@ -748,57 +756,53 @@ void SensorHTS221Thread(ULONG initial_input)
 }
 
 /**
- * @brief  ThreadX entry function for Battery Sensor polling.
- * @param  initial_input ThreadX parameter (unused).
+ * @brief Thread entry for Battery sampling sequence.
+ * @param initial_input Thread argument
  */
 void SensorBatteryThread(ULONG initial_input)
 {
-    /* External assumes */
+    /* hi2c3 required for Expansion Battery */
     extern I2C_HandleTypeDef hi2c3;
-
-    float expansion_voltage;
-    float ina_voltage;
-    uint8_t expansion_percentage;
-    uint8_t ina_percentage;
     
-    HAL_StatusTypeDef expansion_status;
-    HAL_StatusTypeDef ina_status;
-    HAL_StatusTypeDef current_status;
-    
-    uint32_t error_count = 0;
-    static ULONG last_send_time = 0;
-    
-    static const ULONG SEND_INTERVAL_TICKS = 100; /* 1 second @ 100Hz ThreadX tick */
-    static const ULONG POLL_INTERVAL_TICKS = 20;  /* 200ms polling to keep cadence accurate */
-    static const ULONG INA_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
-    
-    float last_ina_voltage = 0.0f;
-    uint8_t last_ina_percentage = 0u;
-    float last_current_amps = 0.0f;
-    bool have_ina_sample = false;
-    ULONG last_ina_ok_time = 0;
-    uint32_t loop_count = 0;
-    ULONG last_current_sample_time = 0;
+    float               expansion_voltage;
+    float               ina_voltage;
+    uint8_t             expansion_percentage;
+    uint8_t             ina_percentage;
+    HAL_StatusTypeDef   expansion_status;
+    HAL_StatusTypeDef   ina_status;
+    HAL_StatusTypeDef   current_status;
+    uint32_t            error_count = 0;
+    static ULONG        last_send_time = 0;
+    static const ULONG  SEND_INTERVAL_TICKS = 100; /* 1 second @ 100Hz ThreadX tick */
+    static const ULONG  POLL_INTERVAL_TICKS = 20;  /* 200ms polling to keep cadence accurate */
+    static const ULONG  INA_STALE_TIMEOUT_TICKS = 1000; /* 10 seconds without valid read => stale */
+    float               last_ina_voltage = 0.0f;
+    uint8_t             last_ina_percentage = 0u;
+    float               last_current_amps = 0.0f;
+    bool                have_ina_sample = false;
+    ULONG               last_ina_ok_time = 0;
+    uint32_t            loop_count = 0;
+    ULONG               last_current_sample_time = 0;
 
     (void)initial_input;
     (void)INA_STALE_TIMEOUT_TICKS;
     (void)have_ina_sample;
     (void)last_ina_ok_time;
     (void)last_current_sample_time;
-
+    
     UartPrint("Battery Thread: Started\r\n");
     last_send_time = tx_time_get();
-    
-    if (last_send_time >= SEND_INTERVAL_TICKS) last_send_time -= SEND_INTERVAL_TICKS;
-    else last_send_time = 0;
-    
+    if (last_send_time >= SEND_INTERVAL_TICKS)
+        last_send_time -= SEND_INTERVAL_TICKS;
+    else
+        last_send_time = 0;
     last_ina_ok_time = last_send_time;
     last_current_sample_time = last_send_time;
 
     /* Give the system 2 seconds to settle exactly as before */
     tx_thread_sleep(200);
 
-    /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) */
+    /* Initialize INA231 battery monitor on I2C2 (STMod+ connector) at address 0x40 */
     if (Battery_Init(&hi2c2) != HAL_OK) {
         UartPrint("Battery Thread: Init failed - continuing with reads anyway\r\n");
         g_battery_power_ready = true;
@@ -815,10 +819,11 @@ void SensorBatteryThread(ULONG initial_input)
         float current_amps = 0.0f;
         ULONG current_time = tx_time_get();
         loop_count++;
-        
         if ((loop_count % 250u) == 0u)
         {
-            UartPrintf("[BATTERY LOOP] alive=%lu tick=%lu\r\n", (unsigned long)loop_count, (unsigned long)current_time);
+            UartPrintf("[BATTERY LOOP] alive=%lu tick=%lu\r\n",
+                       (unsigned long)loop_count,
+                       (unsigned long)current_time);
         }
 
         (void)last_send_time;
@@ -835,7 +840,6 @@ void SensorBatteryThread(ULONG initial_input)
             last_ina_percentage = ina_percentage;
             have_ina_sample = true;
             last_ina_ok_time = current_time;
-            
             current_status = Battery_ReadCurrent(&hi2c2, &current_amps);
             if (current_status == HAL_OK)
             {
@@ -847,15 +851,15 @@ void SensorBatteryThread(ULONG initial_input)
                 last_current_amps = 0.0f;
             }
 
-            if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+            if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
             {
+                /* g_ina231_data usage is intact despite type missing externally */
                 g_ina231_data.voltage = last_ina_voltage;
                 g_ina231_data.current = last_current_amps;
                 g_ina231_data.power = 0.0f;
                 g_ina231_data.percentage = last_ina_percentage;
                 g_ina231_data.timestamp = current_time;
                 g_ina231_data.data_valid = 1u;
-                
                 if (expansion_status == HAL_OK)
                 {
                     g_battery_data.voltage = expansion_voltage;
@@ -880,7 +884,7 @@ void SensorBatteryThread(ULONG initial_input)
             }
             if (error_count >= 3)
             {
-                if (tx_mutex_get(&g_sensorDataMutex, MUTEX_WAIT_TICKS) == TX_SUCCESS)
+                if (tx_mutex_get(&g_sensorDataMutex, 100) == TX_SUCCESS)
                 {
                     g_battery_data.data_valid = 0;
                     g_ina231_data.data_valid = 0;
@@ -893,28 +897,11 @@ void SensorBatteryThread(ULONG initial_input)
 }
 
 /**
- * @brief  ThreadX entry function for generic INA231 tasks (currently sleeps).
- * @param  initial_input ThreadX parameter (unused).
+ * @brief Thread entry for sleeping INA231
+ * @param initial_input Thread argument
  */
 void SensorINA231Thread(ULONG initial_input)
 {
     (void)initial_input;
     while (1) { tx_thread_sleep(TX_WAIT_FOREVER); }
-}
-
-/* ============================================================================
- * Initialization
- * ============================================================================ */
-
-/**
- * @brief  Initialize sensor data structures and mutexes.
- */
-void SensorsInit(void)
-{
-    tx_mutex_create(&g_i2cMutex, "I2C Mutex", TX_INHERIT);
-    tx_mutex_create(&g_sensorDataMutex, "Sensor Data Mutex", TX_INHERIT);
-    
-    memset(&g_hts221_data, 0, sizeof(HTS221_Data_t));
-    memset(&g_battery_data, 0, sizeof(Battery_Data_t));
-    memset(&g_ina231_data, 0, sizeof(INA231_Data_t));
 }

--- a/firmware/Core/Src/sensors.c
+++ b/firmware/Core/Src/sensors.c
@@ -7,8 +7,6 @@
  */
 
 #include "sensors.h"
-#include <string.h>
-#include <math.h>
 
 /* ============================================================================
  * External Fallbacks


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #629

## Type of change
- [x] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Stabilizes INA231 battery telemetry behavior in firmware while keeping the voltage read path deterministic and applying calibrated SOC conversion for the 2S2P pack.

## How to test / Validation
1. Build firmware and flash STM32.
2. Monitor CAN with `candump` for `0x210`/`0x211`.
3. Confirm `0x210` voltage is stable and consistent with multimeter expectations.
4. Confirm `0x210[0]` percentage follows calibrated SOC mapping.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [ ] This PR contains no secrets or sensitive data

## Risks and backward compatibility
Low to medium risk in firmware telemetry behavior; changes are scoped to INA battery read/publish path.

## Related / dependent PRs
- #630 (VSS/feeder path alignment)
- #631 (Qt diagnostics UX alignment)

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.\n\nRelated parent feature: #554