### PR TITLE
fix(telemetry): align VSS and feeder battery paths (#630)

### DIFF
--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/can_ids.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/can_ids.hpp
@@ -25,6 +25,10 @@ constexpr uint32_t ID_STM32_BATTERY = 0x200;
 //   [1..4] float battery voltage (LE)
 constexpr uint32_t ID_RPI_BATTERY = 0x210;
 
+// 0x211: 4 bytes:
+//   [0..3] float battery current (LE, amps)
+constexpr uint32_t ID_RPI_BATTERY_CURRENT = 0x211;
+
 // 0x300: 1 byte:
 //   [0] uint8 gear: 0=N, 1=R, 2=D
 constexpr uint32_t ID_GEAR = 0x300;

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/handlers.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/handlers.hpp
@@ -26,6 +26,7 @@ namespace handlers {
 void HandleSpeed(const can_frame& frame, feeder::Publisher& publisher);
 void HandleStm32Battery(const can_frame& frame, feeder::Publisher& publisher);
 void HandleRpiBattery(const can_frame& frame, feeder::Publisher& publisher);
+void HandleRpiBatteryCurrent(const can_frame& frame, feeder::Publisher& publisher);
 void HandleGear(const can_frame& frame, feeder::Publisher& publisher);
 void HandleEnv(const can_frame& frame, feeder::Publisher& publisher);
 

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/signals.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/feeder/signals.hpp
@@ -38,4 +38,7 @@ constexpr const char* RPI_BATTERY_SOC =
 constexpr const char* RPI_BATTERY_VOLTAGE =
     "Vehicle.ControlUnit.Central.Health.Resources.BatteryVoltage";  // volts (float)
 
+constexpr const char* RPI_BATTERY_CURRENT =
+    "Vehicle.ControlUnit.Central.Health.Resources.BatteryCurrent";  // amps (float)
+
 } // namespace vss

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
@@ -21,8 +21,8 @@ namespace kuksa {
 
 struct KuksaOptions {
     QString address{"localhost:55555"};
-    bool useSsl{false};
-    QString rootCaPath{};
+    bool useSsl{true};
+    QString rootCaPath{"/etc/kuksa/server.crt"};
     QString clientCertPath{};
     QString clientKeyPath{};
     QString token{};
@@ -50,6 +50,7 @@ signals:
 	// 12V battery from RPi (percent + voltage)
     void rpiBatteryPercentReceived(int percent);
     void rpiBatteryVoltageReceived(double volts);
+    void rpiBatteryCurrentReceived(double amps);
 
     // STM32 internal sensors
     void stm32TemperatureReceived(float tempC);

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
@@ -21,8 +21,8 @@ namespace kuksa {
 
 struct KuksaOptions {
     QString address{"localhost:55555"};
-    bool useSsl{true};
-    QString rootCaPath{"/etc/kuksa/server.crt"};
+    bool useSsl{false};
+    QString rootCaPath{};
     QString clientCertPath{};
     QString clientKeyPath{};
     QString token{};

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/README.md
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/README.md
@@ -31,6 +31,7 @@ the loopback interface — no network exposure occurs.
 | `0x200` | same frame | `Vehicle.ControlUnit.STM32.Health.Resources.BatteryVoltage` | V | float |
 | `0x210` | `[0]` uint8 percent, `[1..4]` float LE — V | `Vehicle.ControlUnit.Central.Health.Resources.BatteryLevel` | % | float |
 | `0x210` | same frame | `Vehicle.ControlUnit.Central.Health.Resources.BatteryVoltage` | V | float |
+| `0x211` | `[0..3]` float LE — A | `Vehicle.ControlUnit.Central.Health.Resources.BatteryCurrent` | A | float |
 | `0x300` | `[0]` uint8 — `0`=N, `1`=R, `2`=D | `Vehicle.Powertrain.Transmission.CurrentGear` | — | int32 (`0`/`-1`/`1`) |
 | `0x400` | `[0..3]` float LE — °C, `[4..7]` float LE — % | `Vehicle.ControlUnit.STM32.Health.Resources.Temperature` | °C | float |
 | `0x400` | same frame | `Vehicle.ControlUnit.STM32.Health.Resources.Humidity` | % | float |
@@ -117,6 +118,10 @@ EXTRA_ARGS="--address 127.0.0.1 --port 55555 --vss /etc/kuksa/vss.json --insecur
   "Vehicle.ControlUnit.Central.Health.Resources.BatteryVoltage": {
     "datatype": "float", "type": "sensor", "unit": "V",
     "description": "RPi UPS battery voltage"
+  },
+  "Vehicle.ControlUnit.Central.Health.Resources.BatteryCurrent": {
+    "datatype": "float", "type": "sensor", "unit": "A",
+    "description": "RPi UPS battery current"
   }
 }
 ```

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/handlers.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/handlers.cpp
@@ -74,6 +74,23 @@ namespace handlers {
 				<< " = " << voltage_v << " V\n";
 	}
 
+	void HandleRpiBatteryCurrent(const can_frame& frame, feeder::Publisher& publisher)
+	{
+		// Payload: [0..3]=float current LE (amps)
+		if (frame.can_dlc < 4) {
+			std::cerr << "[Handler] RPi battery current frame too short: "
+					<< static_cast<int>(frame.can_dlc) << " bytes\n";
+			return;
+		}
+
+		const float current_a = can_decode::FloatLe(frame.data);
+
+		publisher.PublishFloat(vss::RPI_BATTERY_CURRENT, current_a);
+
+		std::cout << "[Handler] Published " << vss::RPI_BATTERY_CURRENT
+				<< " = " << current_a << " A\n";
+	}
+
 	void HandleGear(const can_frame& frame, feeder::Publisher& publisher)
 	{
 		// Payload: [0]=u8 gear 0=N, 1=R, 2=D

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/main.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/main.cpp
@@ -79,6 +79,9 @@ int main(int argc, char** argv)
                 case can::ID_RPI_BATTERY:
                     handlers::HandleRpiBattery(frame, publisher);
                     break;
+                case can::ID_RPI_BATTERY_CURRENT:
+                    handlers::HandleRpiBatteryCurrent(frame, publisher);
+                    break;
                 case can::ID_GEAR:
                     handlers::HandleGear(frame, publisher);
                     break;

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/kuksa_reader.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/kuksa_reader.cpp
@@ -123,11 +123,7 @@ void KuksaReader::start()
     // Required paths (guaranteed by kuksa_feeder — must exist in the databroker VSS).
     const std::vector<std::string> requiredPaths = {
         PATH_SPEED,
-        PATH_BATTERY_PERCENT,
-        PATH_BATTERY_VOLT,
         PATH_CURRENT_GEAR,
-        PATH_RPI_BATTERY_VOLTAGE,
-        PATH_RPI_BATTERY_CURRENT
     };
     // Optional paths (custom VSS extensions — may not be registered in every deployment).
     const std::vector<std::string> allPaths = {

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/kuksa_reader.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/kuksa_reader.cpp
@@ -28,6 +28,7 @@ static constexpr const char* PATH_STM32_HUM    = "Vehicle.ControlUnit.STM32.Heal
 
 static constexpr const char* PATH_RPI_BATTERY_PERCENT = "Vehicle.ControlUnit.Central.Health.Resources.BatteryLevel";
 static constexpr const char* PATH_RPI_BATTERY_VOLTAGE = "Vehicle.ControlUnit.Central.Health.Resources.BatteryVoltage";
+static constexpr const char* PATH_RPI_BATTERY_CURRENT = "Vehicle.ControlUnit.Central.Health.Resources.BatteryCurrent";
 
 KuksaReader::KuksaReader(QObject *parent)
     : QObject(parent)
@@ -121,12 +122,18 @@ void KuksaReader::start()
 
     // Required paths (guaranteed by kuksa_feeder — must exist in the databroker VSS).
     const std::vector<std::string> requiredPaths = {
-        PATH_SPEED, PATH_BATTERY_PERCENT, PATH_BATTERY_VOLT, PATH_CURRENT_GEAR
+        PATH_SPEED,
+        PATH_BATTERY_PERCENT,
+        PATH_BATTERY_VOLT,
+        PATH_CURRENT_GEAR,
+        PATH_RPI_BATTERY_VOLTAGE,
+        PATH_RPI_BATTERY_CURRENT
     };
     // Optional paths (custom VSS extensions — may not be registered in every deployment).
     const std::vector<std::string> allPaths = {
         PATH_SPEED, PATH_BATTERY_PERCENT, PATH_BATTERY_VOLT, PATH_CURRENT_GEAR,
-        PATH_STM32_TEMP, PATH_STM32_HUM, PATH_RPI_BATTERY_PERCENT, PATH_RPI_BATTERY_VOLTAGE
+        PATH_STM32_TEMP, PATH_STM32_HUM, PATH_RPI_BATTERY_PERCENT, PATH_RPI_BATTERY_VOLTAGE,
+        PATH_RPI_BATTERY_CURRENT
     };
 
     while (!m_stopRequested.load()) {
@@ -195,6 +202,9 @@ bool KuksaReader::subscribeLoop(const std::vector<std::string>& paths)
         }
         if (auto it = entries.find(PATH_RPI_BATTERY_VOLTAGE); it != entries.end()) {
             emit rpiBatteryVoltageReceived(static_cast<double>(readFloat(it->second, 0.0f)));
+        }
+        if (auto it = entries.find(PATH_RPI_BATTERY_CURRENT); it != entries.end()) {
+            emit rpiBatteryCurrentReceived(static_cast<double>(readFloat(it->second, 0.0f)));
         }
     }
 

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/vss_v6.json
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/vss_v6.json
@@ -6431,6 +6431,20 @@
 												"type": "sensor",
 												"unit": "percent"
 											},
+											"BatteryLevel": {
+												"datatype": "float",
+												"description": "STM32 low-voltage battery state of charge.",
+												"max": 100,
+												"min": 0,
+												"type": "sensor",
+												"unit": "percent"
+											},
+											"BatteryVoltage": {
+												"datatype": "float",
+												"description": "STM32 low-voltage battery voltage.",
+												"type": "sensor",
+												"unit": "V"
+											},
 											"Utilization": {
 												"children": {
 													"CPU": {
@@ -6553,6 +6567,12 @@
 												"description": "RPi UPS battery voltage.",
 												"type": "sensor",
 												"unit": "V"
+											},
+											"BatteryCurrent": {
+												"datatype": "float",
+												"description": "RPi UPS battery current.",
+												"type": "sensor",
+												"unit": "A"
 											}
 										},
 										"description": "Resources attributes and signals",


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #630

## Type of change
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Aligns VSS schema paths with feeder publications and Qt KUKSA subscriptions for battery telemetry (level/voltage/current), reducing runtime path mismatches.

## How to test / Validation
1. Deploy updated VSS and feeder.
2. Run feeder and databroker.
3. Verify no `Path not found` errors for battery paths.
4. Verify Qt receives battery level/voltage/current updates.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [ ] This PR contains no secrets or sensitive data

## Risks and backward compatibility
Medium risk if deployment VSS file differs from branch version; must deploy schema and feeder together.

## Related / dependent PRs
- #632
- #633

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.\n\nRelated parent feature: #555