### PR TITLE
fix(qt): refine diagnostics battery tiles and warning semantics (#631)

### DIFF
--- a/meta-cross/recipes-apps/qt-app/files/qt-app/resources/qml/screens/diagnostics-screen/DiagnosticsScreen.qml
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/resources/qml/screens/diagnostics-screen/DiagnosticsScreen.qml
@@ -47,9 +47,10 @@ Item {
     property bool rpiOnline: !!piHealthReader && piHealthReader.isOnline
     property bool stmOnline: !!vehicleData && (vehicleData.stm32BatteryVoltage > 0 || vehicleData.stm32Battery > 0 || vehicleData.stm32Temperature !== 0 || vehicleData.stm32Humidity !== 0)
 
-    property bool rpiWarn: rpiOnline && (piHealthReader.cpuTemp > 70 || vehicleData.rpiBatteryVoltage < 11.0 || vehicleData.rpiBatteryVoltage > 13.0) || vehicleData.rpiBattery < 20
+    // RPi UPS is a 2S2P pack: valid range is around 6.0V..8.4V
+    property bool rpiWarn: rpiOnline && (vehicleData.rpiBatteryVoltage < 6.0 || vehicleData.rpiBatteryVoltage > 8.4 || vehicleData.rpiBattery < 20)
 
-    property bool stmWarn: stmOnline && (vehicleData.stm32Battery < 20 || vehicleData.stm32BatteryVoltage < 11.0 || vehicleData.stm32BatteryVoltage > 13.0 || vehicleData.stm32Temperature > 60 || vehicleData.stm32Humidity > 85)
+    property bool stmWarn: stmOnline && (vehicleData.stm32Battery < 20 || vehicleData.stm32BatteryVoltage < 11.0 || vehicleData.stm32BatteryVoltage > 13.0)
 
     // ===== Layout =====
     ColumnLayout {
@@ -115,10 +116,25 @@ Item {
 
                 GridLayout {
                     anchors.fill: parent
-                    anchors.margins: 12
+                    anchors.margins: 10
                     columns: 3
-                    rowSpacing: 10
-                    columnSpacing: 10
+                    rowSpacing: 8
+                    columnSpacing: 8
+
+                    MetricTileMini {
+                        label: "SOC"
+                        value: rpiOnline ? fmtInt(vehicleData.rpiBattery, "%") : "--"
+                        warn: rpiOnline && vehicleData.rpiBattery < 20
+                    }
+                    MetricTileMini {
+                        label: "VOLT"
+                        value: rpiOnline ? fmt(vehicleData.rpiBatteryVoltage, 2, "V") : "--"
+                        warn: rpiOnline && (vehicleData.rpiBatteryVoltage < 6.0 || vehicleData.rpiBatteryVoltage > 8.4)
+                    }
+                    MetricTileMini {
+                        label: "CURR"
+                        value: rpiOnline ? fmt(vehicleData.rpiBatteryCurrent, 2, "A") : "--"
+                    }
 
                     MetricTileMini {
                         label: "CPU"
@@ -126,29 +142,13 @@ Item {
                         warn: rpiOnline && piHealthReader.cpuTemp > 70
                     }
                     MetricTileMini {
-                        label: "MEM"
-                        value: rpiOnline ? fmtInt(piHealthReader.memoryPercent, "%") : "--"
-                        warn: rpiOnline && piHealthReader.memoryPercent > 85
-                    }
-                    MetricTileMini {
-                        label: "DISK"
-                        value: rpiOnline ? fmtInt(piHealthReader.diskPercent, "%") : "--"
-                        warn: rpiOnline && piHealthReader.diskPercent > 90
-                    }
-
-                    MetricTileMini {
                         label: "FREQ"
                         value: rpiOnline ? fmtInt(piHealthReader.cpuFreq, "MHz") : "--"
                     }
                     MetricTileMini {
-                        label: "BAT"
-                        value: rpiOnline ? fmtInt(vehicleData.rpiBattery, "%") : "--"
-                        warn: rpiOnline && vehicleData.rpiBattery < 20
-                    }
-                    MetricTileMini {
-                        label: "VOLT"
-                        value: rpiOnline ? fmt(vehicleData.rpiBatteryVoltage, 2, "V") : "--"
-                        warn: rpiOnline && (vehicleData.rpiBatteryVoltage < 11.0 || vehicleData.rpiBatteryVoltage > 13.0)
+                        label: "MEM"
+                        value: rpiOnline ? fmtInt(piHealthReader.memoryPercent, "%") : "--"
+                        warn: rpiOnline && piHealthReader.memoryPercent > 85
                     }
                 }
             }
@@ -171,12 +171,12 @@ Item {
                     columnSpacing: 10
 
                     MetricTileMini {
-                        label: "BATTERY"
+                        label: "SOC"
                         value: stmOnline ? fmtInt(vehicleData.stm32Battery, "%") : "--"
                         warn: stmOnline && vehicleData.stm32Battery < 20
                     }
                     MetricTileMini {
-                        label: "VOLTAGE"
+                        label: "VOLT"
                         value: stmOnline ? fmt(vehicleData.stm32BatteryVoltage, 2, "V") : "--"
                         warn: stmOnline && (vehicleData.stm32BatteryVoltage < 11.0 || vehicleData.stm32BatteryVoltage > 13.0)
                     }
@@ -186,7 +186,7 @@ Item {
                         warn: stmOnline && vehicleData.stm32Temperature > 60
                     }
                     MetricTileMini {
-                        label: "HUMIDITY"
+                        label: "HUM"
                         value: stmOnline ? fmt(vehicleData.stm32Humidity, 0, "%") : "--"
                         warn: stmOnline && vehicleData.stm32Humidity > 85
                     }

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/resources/qml/screens/diagnostics-screen/MetricTileMini.qml
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/resources/qml/screens/diagnostics-screen/MetricTileMini.qml
@@ -15,25 +15,25 @@ Rectangle {
     property string value: ""
     property bool   warn:  false
 
-    radius:       8
+    radius:       6
     color:        root.warn ? AppTheme.alpha(AppTheme.colors.error, 0.1) : AppTheme.colors.surfaceVariant
     border.width: 1
     border.color: root.warn ? AppTheme.colors.error : AppTheme.colors.divider
 
     Layout.fillWidth:   true
     Layout.fillHeight:  true
-    Layout.minimumHeight: 50
+    Layout.minimumHeight: 44
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 6
-        spacing: 2
+        anchors.margins: 5
+        spacing: 1
 
         Text {
             Layout.fillWidth: true
             text:               root.label
             horizontalAlignment: Text.AlignHCenter
-            font.pixelSize:     9
+            font.pixelSize:     8
             font.weight:        Font.Medium
             color:              AppTheme.colors.textTertiary
         }
@@ -42,7 +42,7 @@ Rectangle {
             Layout.fillWidth: true
             text:               root.value
             horizontalAlignment: Text.AlignHCenter
-            font.pixelSize:     16
+            font.pixelSize:     14
             font.weight:        Font.Bold
             color:              root.warn ? AppTheme.colors.error : AppTheme.colors.primary
             opacity:            (root.value === "--") ? 0.4 : 1.0


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #631

## Type of change
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Improves diagnostics battery UX in Qt: consistent compact tile naming/layout, visible current tile in compact mode, and warning semantics aligned with battery-focused expectations.

## How to test / Validation
1. Run Qt app with live telemetry.
2. Open Diagnostics screen.
3. Verify SOC/VOLT/CURR visibility and naming consistency.
4. Verify card warning behavior matches battery thresholds.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [ ] This PR contains no secrets or sensitive data

## Risks and backward compatibility
Low risk, mostly UI behavior and presentation semantics.

## Related / dependent PRs
- #632
- #633

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.\n\nRelated parent feature: #555