### PR TITLE
docs: add daily log for 2026-04-13 (Day 110)

### DIFF
--- a/docs/standups/2026-04-13.md
+++ b/docs/standups/2026-04-13.md
@@ -1,0 +1,119 @@
+# Day 110 - SEAME Automotive Journey
+
+**Date:** Monday, April 13, 2026
+
+**Team:** Afonso, Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team made significant progress across multiple fronts: ML model training, AGL build management, hardware testing, Qt/CAN integration, and planning. Key achievements include Afonso training YOLO with TuSimple dataset, Melanie optimizing metalayer encryption, Gaspar building AGL for the second vehicle, Hugo completing second vehicle fabrication, and Miguel researching YOLO datasets.
+
+---
+
+## Team Progress
+
+### **Afonso** (Qt Development)
+- ✅ Trained YOLO model with TuSimple dataset for improved object detection
+- 🔄 Continuing ML model optimization work
+
+### **Bernardo** (Hardware Integration & Testing)
+- 🔄 Professional development and team support activities
+- 📋 Ongoing hardware validation and testing responsibilities
+
+### **Gaspar** (OS & Development Environment)
+- ✅ Completed planning presentation
+- ✅ Built AGL (Automotive Grade Linux) for second vehicle for testing
+- 🔄 Environment setup and build management
+
+### **Hugo** (Hardware & Fabrication)
+- ✅ Mounted and completed second vehicle assembly for testing purposes
+- ✅ Hardware fabrication milestones achieved
+
+### **Melanie** (GUI & Team Coordination)
+- ✅ Finished INA integration with Qt application
+- ✅ Corrected CAN thread transmission errors
+- ✅ Optimized metalayer to always start with encryption for secure communication
+- 🔄 GUI refinement and team coordination
+
+### **Miguel** (GitHub Project & Agile/Scrum)
+- ✅ Researched ML datasets for YOLO training (TuSimple, other datasets)
+- ✅ Dataset evaluation and ML pipeline support
+- 🔄 Project management and scrum activities
+
+---
+
+## Hardware
+
+- Second vehicle fabrication **completed and mounted** for testing purposes
+- All hardware integration ongoing for dual-vehicle testing capability
+
+---
+
+## Software
+
+### Vehicle Telemetry & Firmware
+- ✅ INA231 battery telemetry mapping stabilization
+- ✅ Firmware calibration for 2S2P battery SOC with INA231
+- ✅ VSS (Vehicle Signal Specification) and feeder battery signal path alignment
+- ✅ Motor and sensor peripheral updates committed
+- ✅ Thread/supervisor and fault handling improvements
+- 🔄 Battery behavior alignment for RPi and main vehicle
+
+### Qt Application (GUI & Diagnostics)
+- ✅ Qt diagnostics battery UX refinement and data semantics
+- ✅ Diagnostics warning logic refinement
+- ✅ Battery/current tiles optimized for small screens
+- ✅ RPi battery behavior aligned with 2S2P model
+- ✅ Diagnostics tile naming unified
+- ✅ CAN thread transmission error corrections
+- ✅ Metalayer optimized with mandatory encryption startup
+
+### ML & Object Detection
+- ✅ YOLO model training with TuSimple dataset
+- 🔄 Dataset research and evaluation ongoing
+- 📋 Preparing for vehicle-based inference testing with second vehicle
+
+### KUKSA & VSS Integration
+- ✅ KUKSA TLS startup defaults restored
+- ✅ STM32 battery VSS nodes added for Qt/KUKSA compatibility
+- ✅ KUKSA VSS node alignment improvements
+
+---
+
+## Challenges
+
+| Problem | Who | Impact | Solution |
+|---------|-----|--------|----------|
+| CAN thread transmission inconsistencies | Melanie | Medium | Corrected transmission error handling in Qt layer |
+| Battery telemetry path alignment | Melanie, Afonso | Medium | Standardized VSS paths across INA231 and firmware layers |
+| Small screen diagnostics layout | Melanie | Low | Optimized battery/current tile positioning for compact displays |
+
+---
+
+## Decisions
+
+- **Metalayer Encryption Default**: Implemented mandatory encryption on metalayer startup for enhanced security in Qt-to-hardware communication
+- **Dual-Vehicle Testing**: Second vehicle now ready for parallel testing and ML model validation
+- **Dataset Selection**: TuSimple dataset selected as primary training set for YOLO model due to comprehensive highway driving scenarios
+
+---
+
+## Standards & Research
+
+- **KUKSA/VSS**: Continued alignment with Vehicle Signal Specification standards for CAN/VSS data mapping
+- **ML Datasets**: Evaluation of TuSimple and alternative datasets for improved YOLO training accuracy
+- **Automotive Grade Linux (AGL)**: Second vehicle built with AGL for consistency with first vehicle testing
+
+---
+
+## Navigation
+
+**Previous:** [Day 109 - April 2, 2026](2026-04-02.md)
+
+**Next:** [Day 111 - Coming Soon](coming-soon.md)
+
+---
+
+*Daily log maintained by the DrivaPi Team | SEAME Automotive Challenge 2026*


### PR DESCRIPTION
Add daily log for April 13, 2026 (Day 110). Comprehensive documentation of team progress including YOLO ML training, Qt/INA231 integration, AGL build for second vehicle, hardware fabrication completion, and dataset research.

Related issue: closes #636

Type: docs (documentation only changes)

Risks and backward compatibility: None.