### PR TITLE
fix(kuksa): finalize TLS defaults and startup wiring (#643)

### DIFF
--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/cli_parser.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/cli_parser.hpp
@@ -25,7 +25,7 @@ struct CliOptions {
     QCommandLineOption canIfOption{QStringList() << "c" << "can-if",
         "CAN interface name", "ifname", "can0"};
 #endif
-    QCommandLineOption kuksaAddrOption{QStringList() << "kuksa-addr",
+    QCommandLineOption kuksaAddrOption{QStringList() << "kuksa-addr" << "kuksa-address",
         "Kuksa databroker address (host:port)", "addr"};
     QCommandLineOption kuksaTlsOption{QStringList() << "kuksa-tls",
         "Use TLS for Kuksa connection"};

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/kuksa_reader.hpp
@@ -21,8 +21,8 @@ namespace kuksa {
 
 struct KuksaOptions {
     QString address{"localhost:55555"};
-    bool useSsl{false};
-    QString rootCaPath{};
+    bool useSsl{true};
+    QString rootCaPath{"/etc/kuksa/server.crt"};
     QString clientCertPath{};
     QString clientKeyPath{};
     QString token{};

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/feeder_cli.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/feeder/feeder_cli.cpp
@@ -14,10 +14,9 @@ FeederConfig ParseArgs(int argc, char** argv)
 {
     FeederConfig config;
     config.publisher_options.address  = "localhost:55555";
-    // Insecure by default: the databroker and feeder co-locate on the same RPi.
-    // Loopback traffic (127.0.0.1) never leaves the device, so TLS adds no meaningful
-    // protection here. Pass --tls (+ --ca) when the broker is accessed over the network.
-    config.publisher_options.use_ssl  = false;
+    // TLS by default in production images.
+    config.publisher_options.use_ssl  = true;
+    config.publisher_options.root_ca_path = "/etc/kuksa/server.crt";
     config.can_interface              = "can1";
 
     int positional_count = 0;
@@ -109,7 +108,7 @@ void PrintUsage(const std::string& program_name)
               << "  can_interface     CAN interface name (default: can1)\n"
               << "  kuksa_address     KUKSA databroker host:port (default: localhost:55555)\n"
               << "\nOptions:\n"
-              << "  --insecure        Use insecure channel (default)\n"
+              << "  --insecure        Use insecure channel\n"
               << "  --tls             Use TLS encrypted channel\n"
               << "  --ca <path>       Root CA certificate path (for TLS)\n"
               << "  --cert <path>     Client certificate path (for mTLS)\n"
@@ -120,7 +119,7 @@ void PrintUsage(const std::string& program_name)
               << "  --help, -h        Show this help message\n"
               << "\nExamples:\n"
               << "  " << program_name << " can1 localhost:55555\n"
-              << "  " << program_name << " --tls --ca ca.crt --cert client.crt --key client.key\n"
+              << "  " << program_name << " --tls --ca /etc/kuksa/server.crt\n"
               << "  " << program_name << " --can-if can0 --address databroker.local:55555 --tls\n"
               << std::endl;
 }

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/cli_parser.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/cli_parser.cpp
@@ -50,7 +50,10 @@ RunConfig buildRunConfig(const QCommandLineParser& parser, const CliOptions& opt
     config.kuksa.address = addr.isEmpty()
         ? QStringLiteral("localhost:55555")
         : addr;
-    config.kuksa.useSsl = parser.isSet(opts.kuksaTlsOption) && !parser.isSet(opts.kuksaInsecureOption);
+    if (parser.isSet(opts.kuksaInsecureOption))
+        config.kuksa.useSsl = false;
+    else if (parser.isSet(opts.kuksaTlsOption))
+        config.kuksa.useSsl = true;
     config.kuksa.rootCaPath = parser.value(opts.kuksaCaOption);
     config.kuksa.clientCertPath = parser.value(opts.kuksaCertOption);
     config.kuksa.clientKeyPath = parser.value(opts.kuksaKeyOption);

--- a/meta-cross/recipes-support/drivapi-audio/files/drivapi-dashboard.service
+++ b/meta-cross/recipes-support/drivapi-audio/files/drivapi-dashboard.service
@@ -15,7 +15,7 @@ ExecStartPre=/bin/sh -c 'test -S /run/wayland-0'
 # Retry loop: wait up to 5s for PipeWire pulse socket
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 10); do [ -S /run/pipewire/pulse/native ] && exit 0; sleep 0.5; done; exit 1'
 
-ExecStart=/usr/bin/myqtapp
+ExecStart=/usr/bin/myqtapp --kuksa-tls --kuksa-ca /etc/kuksa/server.crt
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #643

## Type of change
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Applies a minimal TLS startup alignment across GUI parser options, feeder CLI defaults, and dashboard systemd launch command.

## How to test / Validation
1. Deploy updated package/service.
2. Start dashboard service.
3. Confirm app and feeder connect to KUKSA in TLS mode without extra manual flags.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [ ] This PR contains no secrets or sensitive data

## Risks and backward compatibility
Low risk; scope is limited to startup flags/defaults.

## Related / dependent PRs
- #632
- #633
- #634

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.\n\nRelated parent feature: #555