### PR TITLE
fix(qt): wire RPi battery current into VehicleData (#647)

### DIFF
--- a/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/vehicle_data.hpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/inc/gui/vehicle_data.hpp
@@ -39,6 +39,7 @@ class VehicleData : public QObject
 
     Q_PROPERTY(int rpiBattery READ getRpiBattery WRITE setRpiBattery NOTIFY rpiBatteryChanged)
     Q_PROPERTY(double rpiBatteryVoltage READ getRpiBatteryVoltage WRITE setRpiBatteryVoltage NOTIFY rpiBatteryVoltageChanged)
+    Q_PROPERTY(double rpiBatteryCurrent READ getRpiBatteryCurrent WRITE setRpiBatteryCurrent NOTIFY rpiBatteryCurrentChanged)
     Q_PROPERTY(int distance READ getDistance WRITE setDistance NOTIFY distanceChanged)
     Q_PROPERTY(int odo READ getOdometer WRITE setOdometer NOTIFY odometerChanged)
     Q_PROPERTY(bool autonomousMode READ getAutonomousMode WRITE setAutonomousMode NOTIFY autonomousModeChanged)
@@ -61,6 +62,7 @@ public:
 
     int     getRpiBattery() const;
     double  getRpiBatteryVoltage() const;
+    double  getRpiBatteryCurrent() const;
     int     getDistance() const;
     int     getOdometer() const;
     int     getTemperature() const;
@@ -77,6 +79,7 @@ public:
     void    setStm32Humidity(float humidityPct);
     void    setRpiBattery(int battery);
     void    setRpiBatteryVoltage(double volts);
+    void    setRpiBatteryCurrent(double amps);
     void    setDistance(int distance);
     void    setOdometer(int odo);
     void    setGear(const QString &gear);
@@ -105,6 +108,7 @@ signals:
 
     void rpiBatteryChanged();
     void rpiBatteryVoltageChanged();
+    void rpiBatteryCurrentChanged();
     void distanceChanged();
     void odometerChanged();
     void temperatureChanged();
@@ -127,6 +131,7 @@ private:
 
     int     m_rpiBattery;
     double  m_rpiBatteryVoltage;
+    double  m_rpiBatteryCurrent;
     int     m_distance;
     int     m_odometer;
     QString m_gear;

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/app_controller.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/app_controller.cpp
@@ -116,6 +116,9 @@ int AppController::run(QGuiApplication& app)
         QObject::connect(kuksaReader, &kuksa::KuksaReader::rpiBatteryVoltageReceived,
                          vehicleData.get(), &VehicleData::setRpiBatteryVoltage,
                          Qt::QueuedConnection);
+        QObject::connect(kuksaReader, &kuksa::KuksaReader::rpiBatteryCurrentReceived,
+                 vehicleData.get(), &VehicleData::setRpiBatteryCurrent,
+                 Qt::QueuedConnection);
 
         // CurrentGear only (no SelectedGear in VSS v4 for this use case)
         QObject::connect(kuksaReader, &kuksa::KuksaReader::currentGearReceived,

--- a/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/vehicle_data.cpp
+++ b/meta-cross/recipes-apps/qt-app/files/qt-app/src/gui/vehicle_data.cpp
@@ -36,6 +36,7 @@ VehicleData::VehicleData(QObject *parent)
     , m_stm32Humidity(0.0f)
     , m_rpiBattery(0)
     , m_rpiBatteryVoltage(0.0)
+    , m_rpiBatteryCurrent(0.0)
     , m_distance(0)
     , m_odometer(0)
     , m_gear("N")
@@ -64,6 +65,7 @@ float VehicleData::getStm32Humidity() const { return m_stm32Humidity; }
 
 int VehicleData::getRpiBattery() const { return m_rpiBattery; }
 double VehicleData::getRpiBatteryVoltage() const { return m_rpiBatteryVoltage; }
+double VehicleData::getRpiBatteryCurrent() const { return m_rpiBatteryCurrent; }
 int VehicleData::getDistance() const { return m_distance; }
 int VehicleData::getOdometer() const { return m_odometer; }
 int VehicleData::getTemperature() const { return m_temperature; }
@@ -143,6 +145,15 @@ void VehicleData::setRpiBatteryVoltage(double volts)
         emit rpiBatteryVoltageChanged();
     }
     updateTimestamp("rpiBatteryVoltage");
+}
+
+void VehicleData::setRpiBatteryCurrent(double amps)
+{
+    if (!qFuzzyCompare(m_rpiBatteryCurrent, amps)) {
+        m_rpiBatteryCurrent = amps;
+        emit rpiBatteryCurrentChanged();
+    }
+    updateTimestamp("rpiBatteryCurrent");
 }
 
 void VehicleData::setDistance(int distance)
@@ -307,7 +318,7 @@ void VehicleData::checkStaleProperties()
 
     const QStringList others = {
         "energy", "stm32Battery", "stm32BatteryVoltage", "stm32Temperature", "stm32Humidity",
-        "rpiBattery", "distance", "odo", "gear", "temperature", "autonomousMode"
+        "rpiBattery", "rpiBatteryVoltage", "rpiBatteryCurrent", "distance", "odo", "gear", "temperature", "autonomousMode"
     };
 
     for (const QString& p : others) {


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #647

## Type of change
- [x] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Adds the missing Qt-side wiring for `Vehicle.ControlUnit.Central.Health.Resources.BatteryCurrent` so the diagnostics current tile receives live updates from KuksaReader through VehicleData.

## How to test / Validation
1. Run app with KUKSA feed publishing `...BatteryCurrent`.
2. Confirm `KuksaReader::rpiBatteryCurrentReceived` updates `VehicleData::rpiBatteryCurrent`.
3. Open diagnostics screen and verify current value updates in the RPi tile.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [ ] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
Low risk. Change is additive and scoped to Qt telemetry wiring.

## Related / dependent PRs
- #633
- #634

---
**Approval:** Requires a minimum of **2** approvals.
**Action:** The feature branch **MUST** be deleted upon successful merge.\n\nRelated parent feature: #555