### PR TITLE
Feat/628 usb audio dynamic routing

### DIFF
--- a/meta-cross/recipes-support/drivapi-audio/files/drivapi-dashboard.service
+++ b/meta-cross/recipes-support/drivapi-audio/files/drivapi-dashboard.service
@@ -14,6 +14,8 @@ Environment=PULSE_SERVER=unix:/run/pipewire/pulse/native
 ExecStartPre=/bin/sh -c 'test -S /run/wayland-0'
 # Retry loop: wait up to 5s for PipeWire pulse socket
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 10); do [ -S /run/pipewire/pulse/native ] && exit 0; sleep 0.5; done; exit 1'
+ExecStartPre=/usr/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 1.0
+ExecStartPre=/usr/bin/wpctl set-mute @DEFAULT_AUDIO_SINK@ 0
 
 ExecStart=/usr/bin/myqtapp
 Restart=on-failure


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #123 ## Type of change
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [x] ci: CI configuration changes
- [x] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Configured dynamic USB audio routing for the DrivaPi Qt Dashboard on the AGL (Automotive Grade Linux) Raspberry Pi 5. Because WirePlumber assigns audio device IDs dynamically upon boot, hardcoded sink IDs are unreliable. We resolved this by adding `wpctl` commands as `ExecStartPre` directives in `drivapi-dashboard.service`. These commands dynamically identify, unmute, and set the volume of the `@DEFAULT_AUDIO_SINK@` to 100% right before the Qt dashboard service launches.

## How to test / Validation
1. Deploy the updated `drivapi-dashboard.service` to the target Raspberry Pi 5 AGL system.
2. Reboot the Raspberry Pi 5.
3. Check the service status by running `systemctl status drivapi-dashboard.service` to verify that the `wpctl set-volume` and `wpctl set-mute` pre-flight commands executed without errors.
4. Launch/interact with the dashboard and confirm that audio output successfully routes through the connected USB audio device.
5. Reboot the device a second time and re-verify audio output to ensure the dynamic ID handling continues to work properly.

## Checklist
- [x] I have run the project tests locally and they pass
- [x] CI checks are green for this branch (or I will fix any failures)
- [x] I have added or updated tests where applicable
- [ ] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
**None**. This change utilizes systemd's built-in `ExecStartPre` behavior and standard WirePlumber default sink targeting. It should not negatively impact other services. 

## Related / dependent PRs
None.

 ---
**Approval:** Requires a minimum of **2** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.