### PR TITLE
docs: add daily log for 2026-05-08

### DIFF
--- a/docs/standups/2026-05-08.md
+++ b/docs/standups/2026-05-08.md
@@ -1,0 +1,90 @@
+# Day 128 - SEAME Automotive Journey
+
+**Date:** Friday, May 8, 2026
+
+**Team:** Afonso, Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+Today the team focused on sprint closure and vehicle debugging while keeping control and perception research active. Afonso prepared and delivered the retrospective presentation, and Melanie supported retrospective material preparation. In parallel, the car-debugging effort continued across multiple members, while object detection and Stanley+IL work advanced with open tuning tasks.
+
+---
+
+## Team Progress
+
+### **Afonso** (Qt Development)
+- ✅ Prepared and delivered the official Sprint Retrospective presentation.
+
+### **Bernardo** (Hardware Integration & Testing)
+- 🔄 Conducted object-detection model training sessions; current results were inconclusive and require further tuning.
+
+### **Gaspar** (OS & Development Environment)
+- 🔄 Performed technical debugging and system checks on the car.
+
+### **Hugo** (Hardware & Fabrication)
+- 🔄 Worked on resolving hardware/software integration issues during car debugging.
+
+### **Melanie** (GUI & Team Coordination)
+- ✅ Assisted in preparing Sprint Retrospective materials.
+- 🔄 Performed hands-on car debugging.
+
+### **Miguel** (GitHub Project & Agile/Scrum)
+- ✅ Provided technical support to the team during morning vehicle debugging.
+- 🔄 Researched and progressed Stanley controller implementation integrated with Imitation Learning (IL).
+
+---
+
+## Hardware
+
+- 🔄 Car debugging remained active across Gaspar, Hugo, Melanie, and Miguel, focusing on integration stability and system-level checks.
+- 🔄 Hardware/software integration troubleshooting continued on the vehicle to isolate unresolved behavior.
+
+---
+
+## Software
+
+- ✅ Sprint Retrospective artifacts were prepared and presented.
+- 🔄 Stanley + IL control-system research and implementation work continued.
+- 🔄 Object-detection training pipeline remains under tuning due to unsatisfactory model outcomes.
+- ✅ No repository commits or PR lifecycle events were recorded for this date.
+
+---
+
+## Challenges
+
+| Problem | Who | Impact | Solution |
+|---------|-----|--------|----------|
+| Object-detection model training quality below target | Bernardo | Medium | Continue hyperparameter/data tuning and rerun training with updated settings |
+| Vehicle integration issues during debugging sessions | Gaspar, Hugo, Melanie, Miguel | High | Keep systematic on-car diagnostics and isolate hardware/software interactions step by step |
+| Stanley + IL integration still incomplete | Miguel | Medium | Continue controller research and iterative integration testing with IL outputs |
+
+---
+
+## Decisions
+
+**Object-detection progression strategy:**
+- Option A: Freeze the current model and shift focus to other tasks
+- Option B: Continue tuning and retraining until performance is acceptable
+- **Decision:** Continue tuning and retraining before final model selection.
+
+**Vehicle debugging execution:**
+- Option A: Limit debugging to a single specialist
+- Option B: Keep multi-role collaborative debugging sessions on the car
+- **Decision:** Maintain collaborative debugging to speed up issue isolation.
+
+---
+
+## Standards & Research
+
+- Continued practical research on Stanley controller integration with Imitation Learning (IL).
+- Reinforced iterative model-development practice for object detection by treating inconclusive runs as tuning input.
+
+---
+
+## Navigation
+
+**Previous:** [Day 127 - May 7, 2026](2026-05-07.md) | **Next:** [Day 129 - May 11, 2026](2026-05-11.md)
+
+---


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #703

## Type of change
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Adds the daily standup log for 2026-05-08 with team progress, challenges, decisions, and navigation links, based on the provided raw notes.

## How to test / Validation
1. Open `docs/standups/2026-05-08.md`.
2. Confirm required sections are present and formatted consistently with previous daily logs.
3. Verify navigation links reference Day 127 and Day 129.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approval (daily log PR).
**Action:** The feature branch **MUST** be deleted upon successful merge.
