### PR TITLE
docs: add daily log for 2026-07-03

### DIFF
--- a/docs/standups/2026-07-03.md
+++ b/docs/standups/2026-07-03.md
@@ -1,0 +1,89 @@
+# Day 161 - SEAME Automotive Journey
+
+**Date:** Friday, July 03, 2026
+
+**Team:** Afonso, Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+The team focused on controller stability and build-system maintenance. Gaspar optimized the Stanley controller for higher FPS, but jitter persisted and caused a servo failure, creating a hardware blocker. In parallel, Gaspar and Miguel completed Hailo SDK/firmware updates through BitBake, while Afonso continued debugging the Micro:bit communication failure.
+
+---
+
+## Team Progress
+
+### Afonso - Qt Development
+- 🔄 Investigated and debugged the issue causing the Micro:bit system failure.
+
+### Bernardo - Hardware Integration & Testing
+- 🔄 Bernardo was unavailable today, so the semaphore workflow remains under calibration and validation..
+
+### Gaspar - OS & Development Environment
+- ✅ Updated Hailo SDK/firmware via BitBake.
+- 🔄 Optimized the Stanley controller for higher FPS; jitter remains and caused servo failure.
+
+### Hugo - Hardware & Fabrication
+- ✅ Away (personal event).
+
+### Melanie - GUI & Team Coordination
+- ✅ Away (personal event).
+
+### Miguel - GitHub Project & Agile/Scrum
+- ✅ Assisted Gaspar with the BitBake update process for the Hailo accelerator.
+
+---
+
+## Hardware
+
+**What was done:**
+
+- Stanley controller runtime optimization increased FPS.
+- A servo failure was observed after jitter events during controller operation.
+
+---
+
+## Software
+
+**Progress:**
+
+- ✅ Hailo SDK/firmware update flow completed through BitBake.
+- ✅ Collaboration between Gaspar and Miguel on accelerator build maintenance was completed.
+- 🔄 Stanley controller tuning is still required to remove jitter after FPS optimization.
+- 🔄 Micro:bit failure root-cause analysis remains in progress.
+- ✅ No PR open/merge/close activity was recorded for this date.
+
+---
+
+## Challenges
+
+| Problem | Who | Impact | Solution |
+|---------|-----|--------|----------|
+| Stanley jitter caused unstable steering output and servo failure | Gaspar | High | Pause aggressive controller runs, inspect servo state, and continue control-output smoothing before new hardware stress runs. |
+| Micro:bit system failure still unresolved | Afonso | Medium | Continue targeted debugging of communication/failure path and validate recovery behavior. |
+
+---
+
+## Decisions
+
+**Controller stability before speed-first runs:**
+- Option A: Keep prioritizing FPS gains in Stanley without changing test strategy.
+- Option B: Prioritize output stability and hardware safety before further aggressive runs.
+- **Decision:** Prioritize stability and hardware-safe validation before additional high-stress controller tests.
+
+**Hailo build maintenance path:**
+- Option A: Postpone firmware/SDK updates until after controller stabilization.
+- Option B: Complete BitBake-based update maintenance now to keep the build baseline current.
+- **Decision:** Complete the Hailo SDK/firmware updates now (done) and continue with stabilization afterward.
+
+---
+
+## Standards & Research
+
+- Continued practical evaluation of Stanley behavior under FPS-focused optimization, with emphasis on safe control output.
+- Reinforced use of BitBake as the standard update path for Hailo SDK/firmware maintenance.
+
+---
+
+**Previous:** [2026-07-02.md](2026-07-02.md) | **Next:** [2026-07-06.md](2026-07-06.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** closes #816 

## Type of change
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Adds and updates standup daily logs under `docs/standups/` for early July 2026, including the new daily entry for `2026-07-03` based on team raw notes and project format.

## How to test / Validation
1. Open `docs/standups/2026-07-03.md` and confirm required sections are present.
2. Confirm date/header/day counter and navigation links are correct.
3. Verify markdown renders correctly in GitHub preview.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

 ---
**Approval:** Requires a minimum of **1** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.