### PR TITLE
docs: add daily standup for 2026-07-09

### DIFF
--- a/docs/standups/2026-07-09.md
+++ b/docs/standups/2026-07-09.md
@@ -1,0 +1,99 @@
+# Day 165 - SEAME Automotive Journey
+
+**Date:** Thursday, July 09, 2026
+
+**Team:** Afonso, Bernardo, Gaspar, Hugo, Melanie, Miguel
+
+---
+
+## What We Did Today
+
+Today the team focused on controller robustness, communication security, and dashboard quality. Bernardo finalized and validated key-based login for radio communication, while Miguel and Afonso continued iterative improvements on the Stanley controller to improve steering responsiveness. In parallel, Gaspar researched moving average filtering for steering stability, Melanie tested lane line rendering behavior in Qt, and Hugo resolved the post-update WiFi regression in the BitBake environment while supporting integration work.
+
+---
+
+## Team Progress
+
+### Afonso - Qt Development
+
+* 🔄 Collaborated with Miguel on Stanley controller tuning for better responsiveness and smoother steering behavior.
+
+### Bernardo - Hardware Integration & Testing
+
+* ✅ Implemented and validated key-based login for radio communication security.
+
+### Gaspar - OS & Development Environment
+
+* 🔄 Investigated applying a moving average filter to steering signals to reduce noise and oscillation.
+
+### Hugo - Hardware & Fabrication
+
+* ✅ Debugged the BitBake environment and resolved the post-update WiFi regression.
+* ✅ Provided technical support to Miguel and Afonso during system integration activities.
+
+### Melanie - GUI & Team Coordination
+
+* 🔄 Conducted testing of lane line rendering behavior in the Qt dashboard and continued UI validation.
+
+### Miguel - GitHub Project & Agile/Scrum
+
+* 🔄 Continued iterative improvements to the Stanley steering controller.
+
+---
+
+## Hardware
+
+**What was done:**
+
+* No new fabrication changes were recorded today; effort centered on integration, communication reliability, and software validation.
+
+---
+
+## Software
+
+**Progress:**
+
+* ✅ Key-based radio login implemented and validated for secure communication flow.
+* ✅ BitBake/WiFi regression fixed after environment updates.
+* 🔄 Stanley controller tuning ongoing (performance and steering responsiveness).
+* 🔄 Steering signal filtering research ongoing (moving average approach).
+* 🔄 Qt lane line rendering testing ongoing to improve visual consistency.
+
+---
+
+## Challenges
+
+**Problem:** Steering stability and smoothness under changing signal conditions.
+- **Who:** Gaspar, Miguel, Afonso
+- **Impact:** High
+- **Solution:** Continue moving average filter evaluation and iterate Stanley parameter tuning using integration feedback.
+
+**Problem:** Loss of WiFi functionality after environment update.
+- **Who:** Hugo
+- **Impact:** High
+- **Solution:** Debugged BitBake environment changes and restored network behavior.
+
+---
+
+## Decisions
+
+**Steering quality strategy:**
+- Option A: Tune only Stanley parameters.
+- Option B: Combine controller tuning with steering signal pre-filtering.
+- **Decision:** Proceed with combined approach (Stanley tuning + moving average filter investigation).
+
+**Radio communication hardening:**
+- Option A: Keep existing access flow.
+- Option B: Enforce key-based login.
+- **Decision:** Key-based login implementation validated and adopted.
+
+---
+
+## Standards & Research
+
+* Investigated steering signal smoothing methods (moving average) as part of control-system stabilization.
+* Reinforced secure communication practices by validating key-based authentication in the radio link.
+
+---
+
+**Previous:** [2026-07-08.md](2026-07-08.md) | **Next:** [2026-07-10.md](2026-07-10.md)


### PR DESCRIPTION
# Pull Request

**Related issue(s):** #831 

## Type of change
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] docs: Documentation only changes
- [ ] style: Formatting, missing semicolons, etc (no code change)
- [ ] refactor: Code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding or updating tests
- [ ] ci: CI configuration changes
- [ ] chore: Maintenance tasks
- [ ] spike: Investigation / research

## Summary
Adds the daily standup log for 2026-07-09 at `docs/standups/2026-07-09.md`, based on the team raw notes for that day. The entry includes completed and in-progress items, challenges, decisions, and continuity links to adjacent standups.

## How to test / Validation
1. Open `docs/standups/2026-07-09.md`.
2. Confirm the date, day counter, and team progress sections match the provided raw notes.
3. Check navigation links to `2026-07-08.md` and `2026-07-10.md`.

## Checklist
- [ ] I have run the project tests locally and they pass
- [ ] CI checks are green for this branch (or I will fix any failures)
- [ ] I have added or updated tests where applicable
- [x] I have updated documentation (if applicable)
- [ ] I have added/updated any migration notes (if database or protocol changes)
- [x] I have requested appropriate reviewers and added labels if needed
- [x] This PR contains no secrets or sensitive data

## Risks and backward compatibility
None.

## Related / dependent PRs
None.

---
**Approval:** Requires a minimum of **1** approvals. <br>
**Action:** The feature branch **MUST** be deleted upon successful merge.